### PR TITLE
Support loading and saving Canonical MPC QP models

### DIFF
--- a/src/mpc_tools/mpcqp.py
+++ b/src/mpc_tools/mpcqp.py
@@ -373,6 +373,32 @@ class CanonicalMPCQP(object):
             T = Affine(np.eye(nv), np.zeros(nv))
         self.T = T
 
+    def save(self, file):
+        np.lib.npyio._savez(file, args=[], kwds={
+            "H": self.H,
+            "F": self.F,
+            "Q": self.Q,
+            "G": self.G,
+            "W": self.W,
+            "E": self.E,
+            "TA": self.T.A,
+            "Tb": self.T.b
+        }, compress=False, allow_pickle=False)
+
+    @staticmethod
+    def load(file):
+        data = np.load(file)
+        qp = CanonicalMPCQP(H=data["H"],
+                            F=data["F"],
+                            Q=data["Q"],
+                            G=data["G"],
+                            W=data["W"],
+                            E=data["E"],
+                            T=Affine(data["TA"],
+                                     data["Tb"]))
+        data.close()
+        return qp
+
     @staticmethod
     def from_mathematicalprogram(prog, u, x):
         u = np.asarray(u)

--- a/src/mpc_tools/test/test_canonical_qp.py
+++ b/src/mpc_tools/test/test_canonical_qp.py
@@ -1,0 +1,38 @@
+import unittest
+import numpy as np
+import mpc_tools.mpcqp as mqp
+import tempfile
+
+
+class TestCanonicalQP(unittest.TestCase):
+    def test_save_load(self):
+        np.random.seed(100)
+        for i in range(100):
+            nx = np.random.randint(0, 5)
+            nu = np.random.randint(0, 5)
+            H = np.random.randn(nu, nu)
+            F = np.random.randn(nx, nu)
+            Q = np.random.randn(nx, nx)
+            nconstr = np.random.randint(0, 5)
+            G = np.random.randn(nconstr, nu)
+            W = np.random.randn(nconstr)
+            E = np.random.randn(nconstr, nx)
+            T = mqp.Affine(np.random.randn(nx + nu, nx + nu),
+                           np.random.randn(nx + nu))
+            qp = mqp.CanonicalMPCQP(H, F, Q, G, W, E, T=T)
+            fname = tempfile.mkstemp(suffix=".npz")[1]
+            qp.save(fname)
+            qp2 = mqp.CanonicalMPCQP.load(fname)
+
+            self.assertTrue(np.allclose(qp.H, qp2.H))
+            self.assertTrue(np.allclose(qp.F, qp2.F))
+            self.assertTrue(np.allclose(qp.Q, qp2.Q))
+            self.assertTrue(np.allclose(qp.G, qp2.G))
+            self.assertTrue(np.allclose(qp.W, qp2.W))
+            self.assertTrue(np.allclose(qp.E, qp2.E))
+            self.assertTrue(np.allclose(qp.T.A, qp2.T.A))
+            self.assertTrue(np.allclose(qp.T.b, qp2.T.b))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/symbolic_explicit.ipynb
+++ b/src/symbolic_explicit.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "%pylab inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import pydrake.solvers.mathematicalprogram as mp\n",
+    "from boxatlas.contactstabilization import MixedIntegerTrajectoryOptimization\n",
+    "import numpy as np\n",
+    "import mpc_tools.mpcqp as mqp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "N = 1\n",
+    "dt = 0.05\n",
+    "ts = np.linspace(0, N * dt, N + 1)\n",
+    "mass = 1\n",
+    "dim = 2\n",
+    "q_max = np.ones(dim)\n",
+    "q_min = -q_max\n",
+    "v_max = 10 * np.ones(dim)\n",
+    "v_min = -v_max\n",
+    "a_max = 10 * np.ones(dim)\n",
+    "a_min = -a_max\n",
+    "f_max = 10 * np.ones(dim)\n",
+    "f_min = -f_max\n",
+    "\n",
+    "prog = MixedIntegerTrajectoryOptimization()\n",
+    "qcom = prog.new_piecewise_polynomial_variable(ts, dimension=dim, degree=2)\n",
+    "prog.add_continuity_constraints(qcom)\n",
+    "vcom = qcom.derivative()\n",
+    "prog.add_continuity_constraints(vcom)\n",
+    "acom = vcom.derivative()\n",
+    "\n",
+    "force = prog.new_piecewise_polynomial_variable(ts, dimension=dim, degree=0)\n",
+    "\n",
+    "for j in range(len(ts) - 1):\n",
+    "    for i in range(dim):\n",
+    "#         qcom.functions[j].coeffs[-1][i] = 1.0 / mass * force(ts[j])[i]\n",
+    "        prog.AddLinearConstraint(mass * acom(ts[j])[i] == force(ts[j])[i])\n",
+    "    \n",
+    "for j in range(len(ts) - 1):\n",
+    "#     q = qcom.from_below(ts[j + 1])\n",
+    "#     v = vcom.from_below(ts[j + 1])\n",
+    "    q = qcom(ts[j])\n",
+    "    v = vcom(ts[j])\n",
+    "    for i in range(dim):\n",
+    "        prog.AddLinearConstraint(q[i] <= q_max[i])\n",
+    "        prog.AddLinearConstraint(q[i] >= q_min[i])\n",
+    "        prog.AddLinearConstraint(v[i] <= v_max[i])\n",
+    "        prog.AddLinearConstraint(v[i] >= v_min[i])\n",
+    "\n",
+    "        prog.AddLinearConstraint(acom(ts[j])[i] <= a_max[i])\n",
+    "        prog.AddLinearConstraint(acom(ts[j])[i] >= a_min[i])\n",
+    "        prog.AddLinearConstraint(force(ts[j])[i] <= f_max[i])\n",
+    "        prog.AddLinearConstraint(force(ts[j])[i] >= f_min[i])\n",
+    "    \n",
+    "    prog.AddQuadraticCost(10 * np.sum(np.power(q, 2)))\n",
+    "    prog.AddQuadraticCost(0.01 * np.sum(np.power(v, 2)))\n",
+    "    prog.AddQuadraticCost(0.001 * np.sum(np.power(acom(ts[j]), 2)))\n",
+    "\n",
+    "    \n",
+    "x = []\n",
+    "for j in range(len(ts) - 1):\n",
+    "    x.append(np.hstack([np.hstack(qcom.functions[j].coeffs[:-1])]))\n",
+    "x = np.vstack(x).T\n",
+    "\n",
+    "u = []\n",
+    "for j in range(len(ts) - 1):\n",
+    "    u.append(np.hstack([np.hstack(qcom.functions[j].coeffs[-1:])] +\n",
+    "                       [np.hstack(force.functions[j].coeffs)]))\n",
+    "u = np.vstack(u).T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ 0.  0.  0.  0.  0.  0.  0.  0.]\n",
+      "[[ 2.  0. -1.  0.  0.  0.  0.  0.]\n",
+      " [ 0.  2.  0. -1.  0.  0.  0.  0.]]\n"
+     ]
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "C must be triangular (up to permutation). Try permuting the problem to mpc_order()",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-9-bdb2fb69a34f>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mqp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmqp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mCanonicalMPCQP\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_mathematicalprogram\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mprog\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mu\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/home/rdeits/locomotion/explorations/drake-mpc/src/mpc_tools/mpcqp.py\u001b[0m in \u001b[0;36mfrom_mathematicalprogram\u001b[0;34m(prog, u, x)\u001b[0m\n\u001b[1;32m    395\u001b[0m         \u001b[0;32mprint\u001b[0m \u001b[0mqp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mf\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    396\u001b[0m         \u001b[0;32mprint\u001b[0m \u001b[0mqp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mC\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 397\u001b[0;31m         \u001b[0mqp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mqp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0meliminate_equality_constrained_variables\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpreserve\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    398\u001b[0m         \u001b[0mqp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mqp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtransform_goal_to_origin\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    399\u001b[0m         \u001b[0mqp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mqp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0meliminate_redundant_inequalities\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/home/rdeits/locomotion/explorations/drake-mpc/src/mpc_tools/mpcqp.py\u001b[0m in \u001b[0;36meliminate_equality_constrained_variables\u001b[0;34m(self, preserve)\u001b[0m\n\u001b[1;32m    309\u001b[0m         \"\"\"\n\u001b[1;32m    310\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 311\u001b[0;31m         \u001b[0mW\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0meliminate_equality_constrained_variables\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mC\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0md\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpreserve\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    312\u001b[0m         \u001b[0;31m# x = W z\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    313\u001b[0m         \u001b[0mnew_program\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0maffine_variable_substitution\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mW\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mzeros\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnum_vars\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/home/rdeits/locomotion/explorations/drake-mpc/src/mpc_tools/mpcqp.py\u001b[0m in \u001b[0;36meliminate_equality_constrained_variables\u001b[0;34m(C, d, preserve)\u001b[0m\n\u001b[1;32m     78\u001b[0m         \u001b[0mnonzeros\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnonzero\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mC\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mj\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     79\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnonzeros\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 80\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"C must be triangular (up to permutation). Try permuting the problem to mpc_order()\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     81\u001b[0m         \u001b[0mi\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnonzeros\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     82\u001b[0m         \u001b[0;32massert\u001b[0m \u001b[0md\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"Right-hand side of the equality constraints must be zero\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: C must be triangular (up to permutation). Try permuting the problem to mpc_order()"
+     ]
+    }
+   ],
+   "source": [
+    "qp = mqp.CanonicalMPCQP.from_mathematicalprogram(prog, u, x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SolutionResult.kSolutionFound"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "    \n",
+    "q0 = [0.5, 0.5]\n",
+    "v0 = [0, -1]\n",
+    "for i in range(dim):\n",
+    "    prog.AddLinearConstraint(qcom(0)[i] == q0[i])\n",
+    "    prog.AddLinearConstraint(vcom(0)[i] == v0[i])\n",
+    "\n",
+    "prog.Solve()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "qcom = prog.get_piecewise_solution(qcom)\n",
+    "vcom = qcom.derivative()\n",
+    "acom = vcom.derivative()\n",
+    "force = prog.get_piecewise_solution(force)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x7fda438224d0>]"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAhAAAAFkCAYAAABxWwLDAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAPYQAAD2EBqD+naQAAIABJREFUeJzt3XmYXFWd8PHvISRhCYSEhDTZgEQyBNRAGhRI2NSAyLAk\nUaFRB+PysoyORBkdx2VGed9hZkTQUYR3UFGeYYLo68DMo2wu+AhZCJ2whAABAmFJqAAJAUxCtvP+\ncbqsutXd6a5KV1dV9/fzPP2k7rn31j19vDE/zu8sIcaIJElSOXardQUkSVLjMYCQJEllM4CQJEll\nM4CQJEllM4CQJEllM4CQJEllM4CQJEllM4CQJEllM4CQJEllM4CQJEllqyiACCFcEkJYGULYFEJY\nHEKYvpNrTwoh7Cj52R5CmFR5tSVJUi2VHUCEEM4FrgYuB44E7gVuDyGM3cltETgUaGr7ORB4suza\nSpKkuhDK3UwrhLAQeCDG+JmisuXAf8UYv9LB9ScBvwOGxRhf38X6SpKkOlBWD0QIYSDQDNxdcuou\n4Pid3QosDSGsDiH8JoRwclm1lCRJdWX3Mq8fAQwAciXlOVJqoiNrgE8DrcBg4K+A34YQTowx3tfR\nDSGE/YHTgGeBzWXWUZKk/mwP4GDgzhjjq9V6SLkBRNlijCuAFUVFi0II44C/BToMIEjBw03Vrpsk\nSX3YR4D/rNaXlxtAvAJsB0aVlI8CXirjexaSfrHOPAvwH//xH0yePLmc+vVrc+fO5eqrr651NRqO\n7VY+26wytlv5bLPynHACbNz4GPBRaPu3tFrKCiBijFtDCK3ADOC2olMzgFvL+KqppNRGZzYDTJ48\nmalTp5ZTxX5t6NChtlcFbLfy2WaVsd3KZ5t1Xy4H27Zliqo6BKCSFMZVwI1tgcQC4EJgHHAtQAjh\nCmB0jPGCtuPPkaKgR4FBwMeAmcCsXa28JElKzjwTtmzpveeVHUDEGG8JIQwHvkZaz2EZcHqM8YW2\nS5pIAUXeIOBfgbHAJlIg8YEY4527UnFJklTw8MO9+7yKBlHGGK8Druvk3JyS428B36rkOZIkqXvK\nXNZpl7kXRh/S0tJS6yo0JNutfLZZZWy38tlm3TdoUO8+r+yVKHtDCGEq0Nra2urgGUmSupDLwfjx\n+TEQS0hrPtIcY1xSrWfaAyFJUoObPbt3B1CCAYQkSQ3v+ed7/5kGEJIkNbBcDl58sfefawAhSVID\nmz0btm/v/ecaQEiS1MBqkb4AAwhJkhra+vXZ49166V92AwhJkhpULgebNmXLDjigd55tACFJUoOa\nPbvdBlqMKt0vu0oMICRJakC5HNx/f7Zs8GC48sreeb4BhCRJDWj2bNi6NVt29NEwfHjvPN8AQpKk\nBtNZ78Mvf9l7dTCAkCSpwcya1XHvQ28NoAQDCEmSGkouB4sXZ8t6u/cBDCAkSWooM2fWvvcBDCAk\nSWoIuRxMnw6LFmXLa9H7ALB77z9SkiSVa/ZsuO++9uW16H0AAwhJkupeLgcPPJAt2313ePe7a9P7\nAAYQkiTVvdmz4a23smXvfjfce29t6gOOgZAkqa511PtQq3EPxQwgJEmqYx31PtRq3EMxAwhJkupQ\nftbFggXZ8nrofQDHQEiSVJfqbdZFKQMISZLq0OrV2eNaz7ooZQAhSVKdyeXgxRezZbWedVHKMRCS\nJNWZ97wHtmwpHO+zT/30POQZQEiSVCdyOTjmGFi+PFs+cmR9jHsoZgAhSVKdmDmz/ZoPAAce2Pt1\n6YoBhCRJNZafsrlwYbZ8991h2rT6S1+AgyglSaq5zqZs1tvAyWL2QEiSVCON2POQZw+EJEk10og9\nD3kGEJIk1UjpWg/1tljUzpjCkCSpl+VyKUXx3HPZ8nzPQ71N2eyIPRCSJPWy2bNh/vzC8eDBaY+L\nRuh5yLMHQpKkXtLZDptjxjROz0OePRCSJPWSzgZN1uNCUV0xgJAkqZesXJk9bqRBk6VMYUiSVGW5\nHBx1FKxZky1vpEGTpeyBkCSpys44Ax58sHDciIMmSxlASJJUBblcGvPw/PPtp2vmB002MgMISZKq\noLMBk9CYgyZLGUBIklQFpatMDh6ceh4OPLCxUxd5BhCSJPWgXA5mzoRVq7LlRx/d+GmLYgYQkiT1\noJkzswtF9YUBkx1xGqckST0gl4Pjj2+/NXcjrjLZHfZASJLUA0p7HvL6woDJjhhASJK0i7ZsgYce\nypY18iqT3WEKQ5KkCuXTFsOGwcaN2XONvMpkd9gDIUlShUrTFvvsAyNH9p2pmjtTUQ9ECOGSEMLK\nEMKmEMLiEML0bt43LYSwNYSwpJLnSpJUa/ktuSdMgEWLsudGjoSnn+7bPQ95ZQcQIYRzgauBy4Ej\ngXuB20MIY7u4byjwU+A3FdRTkqS6kF9h8plnYMeO7Lm+OmCyI5X0QMwFro8x3hBjfCLGOBd4Hri4\ni/uuA24CFnZxnSRJdaujFSYnTIBp0/p+2qJYWQFECGEg0AzcXXLqLuD4ndw3BzgE+Ea5FZQkqdby\naYtDDkmbYxU7+uj+k7YoVu4gyhHAACBXUp4Dmjq6IYRwKPBPwPQY444QQtmVlCSplko3xtprL2hq\n6h+DJTtT1VkYIYTdSGmLf4gxPp0v7u79c+fOZejQoZmylpYWWlpaeq6SkiR1obTXoakp9TrU2rx5\n85g3b16mbMOGDb3y7BBj7P7FKYWxEfhgjPG2ovLvAFNijKeUXD8UWA9soxA47Nb2eRtwaozxng6e\nMxVobW1tZerUqWX9QpIk9ZRcDs44A1pbs+XTptXvxlhLliyhubkZoDnGWLVZj2X1QMQYt4YQWoEZ\nwG1Fp2YAt3Zwy+vA20vK/ho4BZgNPFvO8yVJ6k2nnw5LlxaO++rGWJWoJIVxFXBjWyCxALgQGAdc\nCxBCuAIYHWO8IKbujeXFN4cQ1gKbY4yP7VLNJUmqogUL2i9Pnd8YSxUEEDHGW0IIw4GvAQcCy4DT\nY4wvtF3SRAooJElqOLkcvOc98NhjsFvJXMX+tM5DVyoaRBljvI60rkNH5+Z0ce83cDqnJKlOnXgi\nrFiRPm/f3r+Wpy6He2FIkvq1XC5N01yzBmJMK0wWyy9PrSwDCElSv1a6xsOgQWl77jzTFh0zgJAk\n9WurV2ePDzwQxo5NPRKmLTpnACFJ6nfyaYsXX2y/SNTYsc606A4DCElSv+PS1LvOAEKS1O+sWpU9\nrpelqRtJJdt5S5LUcPI7ao4eDS+8kD3nQMny2QMhSeoXStMWQ4ak7bdNW1TGAEKS1OfFCMuXZ8sO\nOMC0xa4whSFJ6rNyOTj+eNh3X1i/PnvOtMWusQdCktRnnX02LFpUOHZZ6p5jACFJ6pOefBKWLMmW\nuSx1zzGFIUnqM4pnWhx+OAwYkD1v2qLn2AMhSeozSmdavPOdsOeeLktdDQYQkqQ+Yft2WLYsW/ba\na9DaWpv69HWmMCRJDS2Xg+OOSzMtNmzInjNlUT32QEiSGtoZZ2R7GZxp0TsMICRJDeuPf4SlS7Nl\nzrToHaYwJEkNJT/TYuRIOOmktJNmMdMWvcMeCElSQ5k1C+bPLxxPngyDBjnTorcZQEiSGsarr7Zf\nHOrVV01Z1IIpDElSXcunLMaNgzFjYOvW7HlTFrVhD4Qkqa6VLg41ZUraituURW0ZQEiS6taOHfDo\no9myN96ABx+sTX1UYApDklRX8imLQw6BESPSapLFTFnUB3sgJEl1pTRlMWlSmrJpyqK+GEBIkurK\nU09lj7dtg3vvrU1d1DkDCElSTeVyqddh9WrYsiUdFzNlUZ8MICRJNVWashg3DsaPN2VR7wwgJEk1\n9eyz2eOBA01ZNAIDCElSr8qnLNasgRDgxRez501ZNAYDCElSrypNWRxwAEycmAILUxaNwwBCktSr\nnnsuezxkSHZzLDUGF5KSJPWan/88zbYoZsqiMdkDIUmqqlwOZs5MS1K//jq8//1pdcm1a01ZNDID\nCElSVZ1xBrS2Fo7feAMWLKhdfdQzTGFIkqrmtttg6dJs2Zo1tamLepYBhCSpR+VycPzxsN9+cM45\nsO++2fOOeegbTGFIknpUacpi0qS0OJQrS/YtBhCSpB7zi1/AkiXZsldegaefrk19VD0GEJKkihVv\nhLVpE7z0EowYkYKGPFMWfZMBhCSpYqWrSk6cmI7zS1Wbsui7DCAkSRWJEZ54on3ZqFFuhtUfOAtD\nktRtuRxMnw6HHAIjR2ZTFWC6oj+xB0KS1G2lKYu3vS31OJiu6H8MICRJ3bJtGyxfni3bscN0RX9l\nCkOS1KVnn4WTT4b167Plpiz6LwMISVKH8uMdRo1KqYpVq+C//xumTYMJE9Kfpiz6L1MYkqQOnX02\nLFpUOB4zBs48M/1I9kBIktr54x+zy1EDvPxybeqi+mQAIUkCCptgDRsGJ54IgwdnzzveQcUqCiBC\nCJeEEFaGEDaFEBaHEKbv5NppIYR7QwivhBA2hhAeCyHMrbzKkqRq+MAHYMECeO21dHz44Y53UOfK\nHgMRQjgXuBq4CJjf9uftIYTJMcYXOrjlT8D3gIfbPk8H/j2E8KcY479XXHNJUo+IEa65pv0mWK++\n6iZY6lwlPRBzgetjjDfEGJ+IMc4Fngcu7ujiGOODMcafxRgfizE+F2P8T+BOYFrl1ZYk7Yr8DIuD\nDoLhw+Gzn4Wmpuw1piy0M2UFECGEgUAzcHfJqbuA47v5HUcBx7XdI0mqgfyKks89l1IWhx8ODz1k\nykLdV24KYwQwAMiVlOeApvaXF4QQngdGtj3z8hjjTWU+W5LUA9avhwcfzJZt3gwHHOCqkuq+3lwH\nYjowBDgWuDKEsKarMRBz585l6NChmbKWlhZaWlqqV0tJ6sPuvBM+8YkUMBQzXdGY5s2bx7x58zJl\nGzZs6JVnhxhj9y9OKYyNwAdjjLcVlX8HmBJjPKWb3/MV4IIY46ROzk8FWltbW5k6dWq36ydJai+X\ng3POSftYvP46nHQSfPe78Nd/nd0E64ADal1T9YQlS5bQ3NwM0BxjXNLV9ZUqqwcixrg1hNAKzABu\nKzo1A7i1jK/ajZQKkSRV2YwZ8MgjheNt22DKFNMV2jWVpDCuAm5sCyQWABcC44BrAUIIVwCjY4wX\ntB1fAjwHPN52/wnAF0hTQSVJVbJpE3z1q9ngAVKvg7Sryg4gYoy3hBCGA18DDgSWAacXrQHRRAoo\n8nYDrgAOBrYBTwNfdA0ISep5uVyaYfHMM2mw5PbtcPDBaTfNPMc7qCdUNIgyxngdcF0n5+aUHH8f\n+H4lz5EklWfmzLSaZN5RR8Edd8CsWdnxDtKucjdOSeojFi+GBx7Ilm3Y4PRMVYcBhCQ1qHy6YvVq\n2Lo1/bnnnulznukKVYsBhCQ1qPxqknnjx8P8+XDuuaYrVH0GEJLUgDZvhkcfzZbtvjuMGWO6Qr2j\nou28JUm1s2gRTJ2axjcUM12h3mQAIUkNIJeD44+H/faDY4+FwYPhnnvc/Eq1YwpDkhrA+94Hy5YV\njvfaC0480XSFasceCEmqY2+8kfasKA4eAF56qTb1kfLsgZCkOpOfnvn007BuXRocecghaXXJPMc7\nqNYMICSpzpx1Ftx/f+H4He+AX//a1SRVXwwgJKlOxAg/+1n71STXr3c1SdUfAwhJqpF8qmLNGhg+\nHIYNg7vvhv33h1dfLVxnukL1yABCkmqkeCXJlSth4ED4r/9K0zVNV6jeGUBIUo2sWpU9HjMGzjkn\nfTZdoXpnACFJveytt+CKK+DFF7PlY8bUpj5SJQwgJKkX5Mc7PPNMGhS5ZQtceiksXJjOmapQozGA\nkKRecPbZaQ+LvKOOgquuql19pF1lACFJVRQj3HILLF6cLS/dCEtqNAYQktSDiqdmDhuWNr/67W/T\nNM116wrXOTVTjc4AQpJ6UPHUTIBBg+DWW+G445yaqb7FAEKSelDxfhUAo0en8Q/g1Ez1Le7GKUk9\nYMOGtGvm6tXZcqdmqq+yB0KSKpQf7/Dkk2lq5sCBcPnlcPvtabttUxXqywwgJKlCZ5wBra2F4ylT\n4KtfTT9SX2cAIUlleust+Nd/zQYPkJ1lIfV1BhCS1IXiqZl77gmbNsFzz6XxDcXLUTs1U/2JAYQk\ndaF0aua++8KDD8LIkU7NVP9lACFJO7F9Ozz+eLZsxAg44oj02amZ6q+cxilJnVi0CI45Bl59NVtu\nqkIygJCkP8vlYPp0OPhgaGqCY49N5b/+NUybBhMmpD9NVUimMCTpz2bNgvnzC8cTJqRNsAYMgNNP\nr129pHpkD4QkkaZklk7LhBQ8SGrPAEJSv7ZuHVx8cRrrUBosONZB6pwpDEn9Ti6X0hUrVsBrr8Ee\ne8DVV8OHPgQf/rDTMqXuMICQ1O+ceio8/HDhePJk+Nzn0menZUrdYwpDUr+Ry8EnPpENHqD9NE1J\nXbMHQlKflV+COr/F9ssvw6BBaXbFypWF6xzrIJXPAEJSn1W6BHVTEyxbllaXdAlqadcYQEjqk555\nBpYuzZbttRfsv3/67FgHadc4BkJSn/Lmm/CVr6SBkdu2Zc+ZqpB6jj0QkhpefqzDk0+maZkAX/oS\nzJkDH/uYqQqpGgwgJDW80mmZzc3wzW+mz6YqpOowhSGpYb34IvzVX7Wflrl+fW3qI/Un9kBIahjF\n0zK3b0/TMocMgYkT4emnC9c51kGqPgMISQ2jdFrm6NGwfDm89ZbTMqXeZgAhqSEsWgQPPJAt22MP\nGDo0fXasg9S7HAMhqa499xycfz4ce6y7ZUr1xABCUt3J5eC442DYMDj4YPjNb+CHP4SnnoJp09JS\n1NOmmaqQaskUhqS6sm1bCg6KB0VOnAif/GT6bKpCqg/2QEiqCzHC7bfDkUdmgweAtWtrUydJnTOA\nkFQTuRxMn556F446Ck4+GT7wARgxAqZMyV7rWAep/lSUwgghXAJcBhwILAPmxhg77FgMIcwELgaO\nBAYDjwL/GGO8q6IaS+oTSqdk7rEH3HYbnHlmWt/BaZlSfSs7gAghnAtcDVwEzG/78/YQwuQY4wsd\n3HIicBfwZeA1YA7wPyGEd8UYH6q45pIa1uuvw6OPZssOPBDOOit9PuAAxzpI9a6SFMZc4PoY4w0x\nxidijHOB50m9DO3EGOfGGK+MMbbGGJ+OMX4VeBI4s/JqS2pEW7fCNdfA294GGzZkz40eXZs6SapM\nWQFECGEg0AzcXXLqLuD4bn5HAPYB1pXzbEmNKT/WoakJ9t0XPvMZOOMMWLLEKZlSIys3hTECGADk\nSspzQFM3v+MyYC/gljKfLakBzZgBjzxSOD7ySLjhhvTZNIXUuHp1HYgQQgvwdeCsGOMrXV0/d+5c\nhubXqW3T0tJCS0tLlWooqacsXw5f/nI2eIA0/kFSz5g3bx7z5s3LlG0ozQ9WSYgxdv/ilMLYCHww\nxnhbUfl3gCkxxlN2cu+5wI/a7r2ji+dMBVpbW1uZOnVqt+snqTbyu2SuWQP77w+HHgo33wzjx8Og\nQbBiReHaadPseZCqacmSJTQ3NwM0xxiXVOs5ZfVAxBi3hhBagRnAbUWnZgC3dnZfW8/DD4Fzuwoe\nJDWe4imZK1fC0qVw1VVw0UVpsKRTMqW+p5IUxlXAjW2BxALgQmAccC1ACOEKYHSM8YK24/OBnwB/\nAywOIYxq+55NMUY7M6UGt2kTPPZYtmzsWPjc59Jnp2RKfVPZ0zhjjLcAlwJfA5YC04HTi9aAaCIF\nFHmfJg28vAZYXfTzncqrLanWtm2DH/0IJk2CdSVzqsaMqU2dJPWeigZRxhivA67r5NyckuNOx0VI\naiz5sQ5PPZUGQ27aBOedB5deCl/4gmkKqT9xN05J3fbe92ZXkJwyBfIDwE1TSP2Lm2lJ6tL998P7\n3td++ek33qhNfSTVngGEpE49+ijMnAnvfje89BIcdlj2vLtkSv2XKQxJGblcWmr6iSfgzTdh3Di4\n8UY4/3x49VWnZEpKDCAk/dnq1dDcnHob8saOhY99LH12SqakPFMYknjlFbjsMpg4EdauzZ7Lle58\nI0nYAyH1S/npmC++CNu3p9TEgAHwpS/BHXfAokWFax3nIKkjBhBSP3TOObBwYeF4zBh48EEYMQIu\nucRxDpK6ZgAh9SObNsG116ZpmcUGD07BAzjOQVL3OAZC6gfeegu+//00xuGLX4SRI7PnTVNIKpc9\nEFIflculVMSKFWnZ6a1b02yKr38d9tnHNIWkXWMAIfVB27bB9Olpz4q8qVPhpz8tHJumkLQrTGFI\nfci2bWnRp8mTs8EDwGuv1aZOkvomeyCkBpafjrl6NQwcmAKIlSvTLIshQ9LMijzHOUjqSQYQUgOb\nNQvmzy8cDxsGra0pXbF2reMcJFWPAYTUgLZvh1tugcWLs+XDhqXgAZyOKam6HAMhNZDt22HePHj7\n29PmVkOGZM+bppDUWwwgpDqXy8G0aTBqVJp+ef75MGFCWm768cfTuQkT0p+mKST1FlMYUh3btg1O\nOAGefLJQ9s53wq9+VTg2TSGpFuyBkOrQ1q3wk5+k6ZjFwQPAm2/WpEqSlGEPhFQHiqdjDhgAW7bA\nc8+l6Zh77w0PPVS41nEOkuqBAYRUB2bOhAULCsf775/WcJgyxemYkuqTAYRUQxs3wvXXt98dc+jQ\nFDyA0zEl1ScDCKkG3ngjbav97W/Dq6/C8OHw8suF86YpJNU7AwipF+THOLz4IuzYkXbH/NOf4IIL\n4O/+zt0xJTUeAwipF5x1VjZN0dSUBkaOH18oM00hqZE4jVOqotWr4fOfb7/k9F57ZYMHSWo09kBI\nPSSfplizJu1JccQRcPPNsOeeMGYMvPBC4VrHOEhqdAYQUg+ZPRvuu69w/NBD8M1vwiWXwFtvOcZB\nUt9iACH1gAceSOs2FBs7Fr785cKxYxwk9SWOgZAqFCPccw+cdhocc0zaKbPYmDE1qZYk9QoDCKkM\n+Z0xm5rSYk+nnJLKbr4ZVq50Z0xJ/YcpDKmbtm2DE0+EFSsKZYcfDkuXQgjp2DSFpP7CHgipCxs3\nwjXXwKGHZoMHgM2bC8GDJPUn9kBIRYqnYo4cmVIUP/pRWm76vPNgv/2ygyWdjimpvzKAkIoUT8Vc\nuTKtHnnRRXDZZWlsgztjSlJiACG1eeIJePjhbNn48fCDHxSO3RlTkhLHQKjfW7gQZs6EyZPTmIZi\nY8fWpk6SVO/sgVC/UjzGYfDgNBVz4UL4i7+A66+HU0+FlhZTFJLUFQMI9SuzZsH8+YXjIUNSkHD2\n2bBbW3+cKQpJ6poBhPqFN9+EH/4QFi3Klh9wQEpfSJLKYwChPm3tWvje99I6Dm+8AcOHw8svF847\nDVOSKmMAoT4nl4MzzoAnn0xBw557woUXwqWXwh57OA1TknqCAYT6lMWL4fTT08JPee94B1x1VeHY\nMQ6StOucxqmGFyPccQe85z3wrnfBhg3Z88UpC0lSzzCAUMPJ5WD69LQy5KRJcMQRqdfhzTfhF79I\nQUQxxzlIUs8zhaGGc845ae2GvGHD4J570k6ZIcAJJzjOQZKqzQBCDeOll+Df/i3tT1Fs2DA46aTC\nsctNS1L1mcJQ3XviCfj0p+Ggg9KUzKam7HlTFJLU++yBUN3JLzf9zDNpb4p161LQ8I1vpJ0xt2wx\nRSFJtWYAobqyYwecfDI8/nih7G1vg2XL0t4VeaYoJKm2KkphhBAuCSGsDCFsCiEsDiFM38m1TSGE\nm0IIT4QQtocQrursWvVfmzenzawOPzwbPEAKKoqDB0lS7ZUdQIQQzgWuBi4HjgTuBW4PIXS28fFg\nYG3b9Q9WWE/1MfmpmIccksY2jB+fVos8/HB45zuz1zrGQZLqTyUpjLnA9THGG/LHIYTTgIuBr5Re\nHGNc1XYPIYRPVlpR9S1/+ZfwwAOF41GjUs/DpElp/wrHOEhSfSsrgAghDASagStKTt0FHN9TlVLf\ntXQpfOtb2eABYO+9U/AATsOUpEZQbgpjBDAAyJWU54Cm9pdLaanpO++E970Ppk6FBQtS6qKYaQpJ\naix1PQtj7ty5DB06NFPW0tJCS0tLjWqk7srlUhriySfhT3+CjRuhuRluvjlN0Vy3zjSFJO2qefPm\nMW/evEzZhtINgaokxBi7f3FKYWwEPhhjvK2o/DvAlBjjKV3c/3tgaYzx811cNxVobW1tZerUqd2u\nn+rD66/DlCnw7LOFsre/HR5+OC01LUmqniVLltDc3AzQHGNcUq3nlJXCiDFuBVqBGSWnZgDze6pS\nakwvvABf/CKMG5cNHiD1QBg8SFLfUUkK4yrgxhBCK7AAuBAYB1wLEEK4AhgdY7wgf0MIYQoQgCHA\nyLbjLTHGx3ax/qqR/GqRa9bAvvumxZ5uvRX22iutFvn738PixYXrHeMgSX1L2QFEjPGWEMJw4GvA\ngcAy4PQY4wttlzSRAopiS4F8rmQqcD6wCphQSaVVe7Nnw333FY6XL4d/+Rf41KdSQOFUTEnq2yoa\nRBljvA64rpNzczooc9OuPmLrVrjllmzvAsCYMfD5opEtTsWUpL7Nf9jVLa+/Dt/+NkyYAB/9aEpV\nFBs9ujb1kiTVRl1P41Tt5Mc4PP88bN8OGzbAW2/B+eennoamJlMUktSfGUCoQ+9/PzxYtHPJmDGw\naFH6M88UhST1X6Yw9Gcxwt13w2mnZYMHSLthFgcPkqT+zR6Ifiyfpli9GnbfHQYOTLMppk5N+1Ks\nWFG41mmYkqRiBhD92Nlnp7RE3rBh8Lvfwcknw8svO8ZBktQ5A4h+6Nln4bvfhfvvz5YPGwantC1G\n7jRMSdLOOAaiH3ngATjvvLRq5I03th/TYJpCktRd9kD0YfkdMZ9+GjZtSms5TJiQeh8+/vG0S6Zp\nCklSJQwg+qhNm2DatBQ85B12GCxbBgMGpOO99zZNIUmqjCmMPmbtWvjHf4SDDsoGDwBbthSCB0mS\ndoU9EA2seEfM/faDI45I+1QMGABz5sCCBbCkaCd4xzhIknqKAUQDK90R85FHUu/DRRfB8OHuiClJ\nqh4DiAa0dSv8/Oftd8QcOxb+/u8Lx07FlCRVi2MgGsiGDXDllTBxInzkI+6IKUmqHXsg6ljxjpjb\ntqUAYst8waGhAAAKO0lEQVSWFDzMneuOmJKk2jGAqGOnnQYPPVQ4Hjs2rR5ZPBjSFIUkqRZMYdSZ\n7dvh1lvhhBOywQPAoEHOpJAk1QcDiBrK5WD69DSm4bjj4J//OS32NHNmOn/YYdnrDR4kSfXCFEYN\nFU/DXLkSFi6Ec8+Fm26Cd73LaZiSpPplAFEjDz7YPkUxbhzcfHPh2GmYkqR6ZQqjF+3YAb/6Fbz3\nvXDUUWlGRbHx42tTL0mSymUPRBXlp2GuXg277QYhwFNPwTHHpJ6GE06AD3/YFIUkqfEYQFTRWWel\naZd5w4fDH/+YdskMIZWZopAkNSJTGFXwyCPwiU9kgwdIG15Nn14IHiRJalT2QOyi4h0x99gDRo6E\nP/wBxoxJW2qvWlW41mmYkqS+wgBiF82cmbbNztt77zQN80MfgvXrnYYpSeqbDCAqlMvBD34AixZl\ny0eNgvPPT5+dhilJ6qsMIMr0yCNw9dWpl2H33VPAsGZN4bxpCklSf2AA0YVcLqUhVq6ETZvSjphj\nxsDll8OnPw1bt5qmkCT1PwYQO7FxY5py+fTThbJJk2DZMhg4sFBmmkKS1N84jbMDa9bAV7+aVoYs\nDh4Atm3LBg+SJPVH/b4Honga5r77wqGHpu20Bw+GT34y9S60thaud4yDJEkGEMyaBfPnF46XL4cr\nroBPfQqGDnVHTEmSOtJvA4g334Sf/KT9apFjxsAXvlA4diqmJEnt9bsA4vnn4Xvfg+uvhzfegGHD\n4JVXCudHj65d3SRJahR9PoDIj3F45pm0ffa6dbDPPmkK5mc+A3vuaYpCkqRy9ekAYts2OOkkeOKJ\nQtkhh8BDD6UgIs8UhSRJ5emT0zhfew2uvBImTswGD5B2wiwOHiRJUvkavgeieBrmfvvBkUfCz36W\n0hUtLam34aGHCtc7DVOSpF3X8AHE7Nlw332F44cfhi9/GS65BJqanIYpSVI1NGwAsXkz3HwzLF6c\nLR83Dr75zcKx0zAlSep5DRdA5HJw7bXpZ+3aNA1zy5bCeadhSpJUfXUfQOTHOKxalQKF9evTXhQf\n/zj8zd+kAMIUhSRJvavuA4jSMQ4HHQRLl6bAIc8UhSRJvavup3GuWZM9HjAgGzxIkqTeV/cBROm0\nS6dhSpJUe3WfwvjlLx3jIElSvan7AMJpmJIk1Z+6T2FIkqT6YwDRh8ybN6/WVWhItlv5bLPK2G7l\ns83qV0UBRAjhkhDCyhDCphDC4hDC9C6uPymE8EDb9U+FEC6srLraGf+iVcZ2K59tVhnbrXy2Wf0q\nO4AIIZwLXA1cDhwJ3AvcHkIY28n1BwO/Av7Qdv0VwL+FEGZWVmVJklRrlfRAzAWujzHeEGN8IsY4\nF3geuLiT6y8GVsUYv9B2/Y+AHwOXVVZlSZJUa2UFECGEgUAzcHfJqbuA4zu57di288XuBI4OIQwo\n5/mSJKk+lDuNcwQwAMiVlOeApk7uaerk+t3bvq/0HMAeAI899liZ1evfNmzYwJIlS2pdjYZju5XP\nNquM7VY+26x8Rf927lHN59TrOhAHA3z0ox+tcTUaT3Nzc62r0JBst/LZZpWx3cpnm1XsYGB+tb68\n3ADiFWA7MKqkfBTwUif3vNTJ9dvavq8jdwIfAZ4FNpdZR0mS+rM9SMHDndV8SFkBRIxxawihFZgB\n3FZ0agZwaye3LQD+sqTsNOCBGOP2Tp7zKvCf5dRNkiT9WdV6HvIqmYVxFfCpEMKcEMJhIYSrgXHA\ntQAhhCtCCD8tuv464KAQwrfbrv8EMAf41q5WXpIk1UbZYyBijLeEEIYDXwMOBJYBp8cYX2i7pIkU\nUOSvfzaE8AHS2hGXAKuBz8YYO+uxkCRJdS7EGGtdB0mS1GDcC0OSJJXNAEKSJJWtVwKIcjbfCiHM\nDCHcFUJYG0LYEEKYH0I4tYPrZocQHg0hbA4hLAshnFPd36L39XS7hRAuCCHsCCFsb/sz/3lQ9X+b\n3lFmm00LIdwbQnglhLAxhPBYCGFuB9f5rmWv7bLdfNd2et+0EMLWEEK71ZF813Z6X4ft5rvW7tqT\nitqhuD0mlVy36+9ajLGqP8C5wFukmRd/QRpM+QYwtpPrrybtk9EMTAT+d9v9U4quOQ7YCvwtMAn4\nO2ALcEy1f5/e+qlSu10ArAdGAgfkf2r9u9awzY5su2cyMB44H3gT+F++a7vcbr5rHd83FHgKuB1Y\nUnLOd62ydvNdy15/Emm9ponF7UHbmMeefNd645dfCHy/pGw58H/K+I5lwFeLjm8GflVyze3ATbX+\nH7vO2+0CYF2tf7c6b7P/B/y06Nh3rbJ2813r+L55wDeAf+jgH0LftcrazXctey4fQOy7k+/skXet\nqimMCjffKv2OAOwDrCsqPo6ON+jq1nfWuyq2G8CQEMKzIYTnQwj/E0I4cpcrXAd6qM2Oov275bvW\n9Xd01G7gu1Z63xzgENI/hB3xXev4vq7aDXzX2t0KLA0hrA4h/CaEcHLJ+R5516o9BqKSzbdKXQbs\nBdxSVNbZBl3d/c56V612exz4OHAmcB5pmfD7QggTd6WydaLiNmv7P53NwGLg/8YYbyo67bvWiS7a\nzXetSAjhUOCfgI/EGHd08r2+ayW62W6+a1lrgE8Ds4GZwBPAb0MI04qu6ZF3rV430wIghNACfB04\nK8bY2b4ZKtFZu8UYFwGLiq6bDywBPgtc2tv1rCPTgSGkreevDCGsiTH+e43r1Ag6bTfftYIQwm7A\nTcA/xBifzhfXsEoNobvt5ruWFWNcAawoKloUQhhHGu9wX08+q9oBRCWbbwEQQjgXuB74YIzx9yWn\nO9uga6ff2UCq1W4ZMcYYQlgMHLoLda0XFbdZjHFV28dHQwhNpN6bfADhu9aJLtqt9Nr+/K7tAxwN\nHBlCuKatbDdSpnELcGqM8R5810p1t90y+vm71pmFpA0q83rkXatqCiPGuBXIb75VbAY72eij7b+g\nfwycF2O8o4NLFnTwnafu7DsbSRXbrSNHkrq8GlqlbdaB3Uhdhnm+a91T2m4d6a/v2uvA20m//5S2\nn+tIXe9TKPzXs+9aVnfbrSP99V3rzFSy7dEz71ovjCD9MCknNQc4jDQF5XXapqAAV5AdvX0+aTrJ\nRaSIKP+zb9E1x7Vd80XStJYvkaa5HF3rEbN13m5fb3tJDiH9BfxxW7s11/r3rVGbXULaKfZtbT9z\ngNdIXaa+a7vWbr5rRW3Wwf0dzSbwXaus3XzXsn8/Pwec3fZ38/C289uBs3v6XeutBrgIWAlsIg24\nmlZ07gbgd0XHv2/7ZUt/flzynbNIU1k2A48WN05f+enpdiPtpPpM2/e9RJq2865a/541bLPPAI+Q\n5lSvBx6gaC0D37XK2813LdtmHdzb7h9C37XK2s13rd3fz78lDZz8EykF8gfgtGq8a26mJUmSyuZe\nGJIkqWwGEJIkqWwGEJIkqWwGEJIkqWwGEJIkqWwGEJIkqWwGEJIkqWwGEJIkqWwGEJIkqWwGEJIk\nqWwGEJIkqWz/H1qV5whcNQpAAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fda046c5b10>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "tsample = np.linspace(ts[0], ts[-1] - 0.001, 100)\n",
+    "plot([qcom(t)[0] for t in tsample], [qcom(t)[1] for t in tsample], \"b.-\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x7fda3e0ae790>]"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAhcAAAFkCAYAAACThxm6AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAPYQAAD2EBqD+naQAAIABJREFUeJzt3X+YXVV96P/3xwAioEHEgJAICQURuQIzICq0FAFBAYHk\n3t4OVgF/PPAUK00t0sK9BKlKbS0B8T5QyvdSRZ2r3PItV3oBQfwBJPIjQ4IQggQSAoQ5AZNMzC/y\na90/9jnOOZPJzJyZs8+POe/X8+xnZq+z9jmf7J46H9b67LUipYQkSVKtvKnRAUiSpPHF5EKSJNWU\nyYUkSaopkwtJklRTJheSJKmmTC4kSVJNmVxIkqSaMrmQJEk1ZXIhSZJqyuRCkiTVVK7JRUTsGRG3\nRcTq4vHdiJg4zDVvjYgbI+LliFgfEQsj4qI845QkSbWT98hFN/B+4KPAqcCRwHeHueZbwElAF3Ao\ncC1wQ0SckWOckiSpRiKvjcsi4lBgIfCBlNLjxbZjgbnAe1JKz+3gul8D/yul9LWytseB/0gpzcol\nWEmSVDN5jlx8CFhdSiwAUkqPAH3Ah4e47sfAJyJiP4CIOBE4GLgnx1glSVKN7JTje+8LrBikfUXx\ntR25Ang38HJEbAG2Ap9LKc0drHNEvINsymUpsHEsAUuS1GZ2BQ4E7k0p/bZWb1p1chERs4ChpicS\ncMyoI4J/Ao4GzgCWAX8E3BgRr6aUHhik/6nA98fweZIktbtPAj+o1ZuNZuTiBrJCzaEsBY4AJg3y\n2iSgd7CLImI34IvAmSmlu4vNT0XEUcBfA4MlF0sBvve97/He9753uNhVIzNnzmT27NmNDqOteM/r\nz3tef97z+nrmmWf4sz/7Myj+La2VqpOLlNJKYOVw/SJiLjAxIo4eUND5NmDOji4rHlsHtG9lx/Uh\nGwHe+9730tHRMfw/QDUxceJE73edec/rz3tef97zhqlpWUFuBZ0ppUXAvcC/RMSxEfFB4Gbgx+VP\nikTEoog4q3jNOuCnwDcj4oSIODAizgc+DdyRV6ySJKl28izohGytihvIkgyAO4G/GNDnYKB8Ya1z\ngWuA24B3AC8Cf5tSujnfUCVJUi3kmlyklPrIRh2G6jNhwPnrwOfzjEuSJOXHvUU0Kl1dXY0Ooe14\nz+vPe15/3vPxIbcVOuslIjqAefPmzbMISJKkKvT09NDZ2QnQmVLqqdX7OnIhSZJqyuRCkiTVlMmF\nJEmqKZMLSZJUUyYXkiSppkwuJElSTZlcSJKkmjK5kCRJNWVyIUmSasrkQpIk1ZTJhSRJqimTC0mS\nVFMmF5IkqaZMLiRJUk2ZXEiSpJoyuZAkSTVlciFJkmrK5EKSJNWUyYUkSaopkwtJklRTJheSJKmm\nTC4kSVJNmVxIkqSaMrmQJEk1ZXIhSZJqyuRCkiTVVK7JRURcHhEPR8S6iFhZxXVXRcQrEbE+In4W\nEYflGackSaqdvEcudgZ+BNw40gsi4jLgEuDPgaOBXuC+iNg9lwglSVJN5ZpcpJS+klK6Hvh1FZdd\nAnwtpXRnSmkhcB6wG3BuHjFKkqTaaqqai4iYCuwL3FdqSyltAn4BfLhRcUmSNN4UCvCZz+Tz3k2V\nXJAlFgkoDGgvFF+TJEk1MGMGLFiQz3vvVO0FETELmDVElwQck1LqGXVUozBz5kwmTpxY0dbV1UVX\nV1c9w5AkqSl1d3fT3d39+/OeHoC+XD4rUkrVXRCxF7D3MN2WFqczStecB8xOKe01zHtPBZ4Hjkop\nLShr/3dgVUrpgkGu6QDmzZs3j46Ojir+JZIktafXXoMDDoANG3qAToDOWg4KVD1ykVJaCYz4sdIq\n33tJRPQCpwALACJiF+AE4NI8PlOSpHayahV89KOwxx5ZgrFoUe0/o+rkohoRMQXYCzgAmBARRxRf\nWpxSWlfsswi4LKV0Z/G164DLI2IxsBi4HFgHdCNJkkalUICzz4YnnoCtW+H+++Gtb4XOztp/Vt4F\nnVcDPWQ1GnsUf//9GEzRwcDviyVSSv9AlmD8D+BR4F3AR0vJiCRJqt4558CvfgVvvAFbtsAVV+T3\nWbmOXBRrJLarkxjQZ8IgbVeTJSaSJGmMNm6E+fMr2159Nb/Pa7ZHUSVJUg1t3gx/8idZglHuXe/K\n7zNNLiRJGqe2bIFPfhLuuQd+8AM47jiYNi37eccd+X1urtMikiSp/goFmD4dnnwS1q6FW2+FP/3T\n7Cj38sv5fL4jF5IkjTMzZsCcOVliAXDLLfX9fJMLSZLGkZTgqacq2/Is3hyMyYUkSePIlVdC34BV\nvfMs3hyMNReSJI0TX/86fPWrMGtWtkjWq69miUWexZuDMbmQJKmFFQpZjcWiRfDb38Kll8JVV2VH\no5hcSJLUwmbMgIcf7j+fM6dxsZRYcyFJUgv7zW8qz+tdvDkYkwtJklrU7bdn26eXq3fx5mCcFpEk\nqQXddRece262WFZvb3Y0onhzMCYXkiS1kEIBTjoJnn4a9toLbrgB9tuv0VFVclpEkqQWcsopWWIB\nsHJltilZszG5kCSpRTz6aONX3xwJkwtJklrAggVw2mmwxx6V7c1QwDmQyYUkSU3umWey6ZBp06Cn\np35bp4+WBZ2SJDWpQgE+/vFs1OLNb4bvfQ/+4A/goYcaHdnQHLmQJKlJnXFGNlKxdSusXw+f+1yj\nIxoZkwtJkprQ8uUwf35lWzMWbw7G5EKSpCbz2mtw8snwpgF/pZuxeHMwJheSJDWBQgGOPx6mToUD\nD4TXX4ef/7z5izcHY0GnJElNYODupu95D3zoQ81fvDkYRy4kSWoCr7xSed7X15g4asHkQpKkBtu4\nEVavrmxrlfqKwTgtIklSA23enO0PsmEDHH549shps+xuOlomF5IkNUChkG2XvmBBllD84Afwp3/a\n6KhqI9dpkYi4PCIejoh1EbFyBP13iohvRMSTEbE2Il6JiO9ERAsPDkmStL3p02HOHFi3DlKCb3+7\n0RHVTt41FzsDPwJuHGH/3YAjga8ARwHnAIcAd+YSnSRJDZBSa+xuOlq5TouklL4CEBHnjbD/GuDU\n8raI+AvgkYiYnFJ6ufZRSpJUPynBl74Ea9ZUtrdyAedArVBzsSeQgNXDdZQkqdldeSXMng3XXAN3\n3ZWNWLR6AedATZ1cRMSbgWuA76eU1jY6HkmSRqNQyBbJWrgQVq2CWbPgb/4mO8ajqmsuImJWRGwb\n4tgaER1jDSwidgJ+CARw8VjfT5KkRimtvrlqVXZ+//2NjSdvoxm5uAHoHqbP0lG87+8VE4vbgQOA\nj4xk1GLmzJlMnDixoq2rq4uurq6xhCJJ0pg9+2zleSOKN7u7u+nurvzz3ZfTMqBVJxcppZXAsI+V\njlZZYjENODGltGok182ePZuOjjEPmEiSVFO33ZZtQlauEcWbg/0Hd09PD52dnTX/rFxrLiJiCrAX\n2QjEhIg4ovjS4pTSumKfRcBlKaU7i4nFv5E9jnoGsHNE7FO8ZmVKaXOe8UqSVEu33w7nnw/nngtL\nl0Jv7/gr3hxM3gWdVwOfLjvvKf48Efhl8feDgdJ8xv5kSQXA/OLPIHtapPwaSZKaUql4c/Hi/lU4\nv/tdmDCh0ZHVT97rXFwAXDBMnwllv78ItNHtlySNNwO3Tu/tba/EAtwVVZKkmlqypPK8t7cxcTSS\nyYUkSTXy6KPbJxPjaeXNkWrqRbQkSWoV8+fDqadCRwfstBOsWNEexZuDMbmQJGkMCgX42MeyrdPf\n8hbo7oY/+INGR9VYTotIkjQGp58OTzwB27Zl26eff36jI2o8kwtJkkZp2bJsOqTceNo6fbRMLiRJ\nGoXly+EjH8nqK8q1YwHnQCYXkiRV6bXX4OST4Y034MEH4bjjYNq07Gc7FnAOZEGnJEkjVCjAWWdl\nNRYpwS9+AcccAw891OjImosjF5IkjdDZZ8Mjj8CmTbB5M1x6aaMjak4mF5IkjcD69RZvjpTJhSRJ\nw9i4MRu12LSpst3izcGZXEiSNITNm+FP/iQr3Lz9dos3R8KCTkmSBlHaLn3BgmxK5Ac/yM6nT290\nZM3PkQtJkgYxfTrMmZOtupkSfPvbjY6odZhcSJI0QErw1FOVbRZvjpzJhSRJZVKCL30J1qypbLd4\nc+SsuZAkqcyVV8Ls2fD3fw8//nE2YtGuW6ePlsmFJKntFQowYwYsXAirVsGsWXDZZdmh6jktIklq\nezNmwMMPZ4kFwP33NzaeVmdyIUlqe88+W3lu8ebYmFxIktrabbfB669Xtlm8OTbWXEiS2k6pxuK5\n52DFimxNi97e7LB4c+xMLiRJbadUY1HS21t5rrFxWkSS1HZeeKHyvLe3MXGMVyYXkqS28uCD2bRI\nOWssastpEUlS23j0UTj9dPjQh2DbtizJsMai9kwuJEnjWql4c+nSbPrjqKPgnntgjz0aHdn4leu0\nSERcHhEPR8S6iFg5iutviohtEfHFPOKTJI1/peLNV16BrVthwgQTi7zlXXOxM/Aj4MZqL4yIc4Bj\ngVdqHZQkqX0sW1Z5/tprjYmjneQ6LZJS+gpARJxXzXURsT9wPXAq8H9zCE2S1AaWLbN4sxGaruYi\nIgL4LvAPKaVnslNJkqqzfDl85COw774waRKsXGnxZr00XXIB/A2wKaX07UYHIklqLaXizZdfzlbe\n3HPPrN5i6tRGR9Zeqq65iIhZxSLLHR1bI6JjNMFERCfwReCC0VwvSWpvpeLNF1+EDRuykQoTi/ob\nzcjFDUD3MH2WjuJ9AY4H3gm8VDYdMgG4NiL+MqU0bUcXzpw5k4kTJ1a0dXV10dXVNcpQJEmt5pUB\njwCsXt2YOJpRd3c33d2Vf777+vpy+axIKeXyxhUfkhV0zk4p7TVMv7cDA0ttfkJWg3FrSum5Qa7p\nAObNmzePjo5RDZhIksaB9euzkYo1a/rbjjsOHnqocTE1u56eHjo7OwE6U0o9tXrfXGsuImIKsBdw\nADAhIo4ovrQ4pbSu2GcRcFlK6c6U0ipg1YD32Az0DpZYSJIEsHEjnH02bNkC738/rF1r8WYj5V3Q\neTXw6bLzUlZ0IvDL4u8HA5XzGZXyH1qRJLWkQiHbLn3+/KzG4n//7+xcjZX3OhcXMExxZkppwjCv\n77DOQpLU3qZPhzlz+s+vvdbkohm4K6okqSVt2wZPPlnZ9uqrjYlFlUwuJEktJyW4+OKstqKcq282\nh2ZcREuSpB1KCb70JbjpJrjuOrj99mzEwgLO5mFyIUlqCaXVN59+Olu/4u//Hi65JDvUXJwWkSS1\nhNLqm6WFsX7848bGox0zuZAktYRFiyrPLd5sXiYXkqSmd/PN8NvfVrZZvNm8rLmQJDW1226Diy6C\nz342G72weLP5mVxIkppOqXjzueeyrdPPPTcbvXiT4+0tweRCktR0SsWbJUuXmli0Ev9PJUlqOi+8\nUHne29uYODQ6JheSpKby4IPZtEg5izdbi9MikqSm8eijcPrp8KEPZXuHFAoWb7YikwtJUsMVCnDa\nadlGZLvvnj0hMnVqo6PSaDktIklquI99DObPz0Yrfvc7+NSnGh2RxsLkQpLUUIsXu3X6eGNyIUlq\nmGXL4KSTYOedK9st4GxtJheSpIZYvhw+8hGYMAHmzoXjjoNp07KfFnC2Ngs6JUl1VSjAJz4BTzwB\nEfDQQ3DkkdlPjQ+OXEiS6uqss7JHTjdvhk2bYObMRkekWjO5kCTVzZo12VMh5SzeHH9MLiRJdbF+\nPZxxBmzZUtlu8eb4Y82FJCk3pd1Nly+HVauyaZA774RrrnHr9PHM5EKSlJuBu5sefni2vPfppzcu\nJuXPaRFJUm6WL688X7++MXGovkwuJEm52LYN1q6tbLO+oj04LSJJqrmU4OKL4bXX4JBDsiJO6yva\nh8mFJKlmSgWcTz0FfX1w3XVwySWNjkr1luu0SERcHhEPR8S6iFhZxXXvjYg7I2J1RKyJiDkRMTnP\nWCVJY1cq4Ozry85vv72x8agx8q652Bn4EXDjSC+IiIOAB4GFwB8B7wf+DtiYR4CSpNpZuLDy3AWy\n2lOu0yIppa8ARMR5VVz2VeA/Ukp/W9a2tJZxSZJq7/rrs7UsylnA2Z6a6mmRiAjgdOC5iLgnIgoR\n8auIOKvRsUmSduzmm+Ev/zIr4nR3UzVbQeckYA/gMuAK4MvAx4A7IuKPU0oPNjI4SVK/UvHmb36T\nPRXymc/ADTdkO52qvVWdXETELGDWEF0ScExKqWcU8ZRGUv49pfSt4u9PRsSHgYvIajEGNXPmTCZO\nnFjR1tXVRVdX1yjCkCQNZ+Dqm4sWmVg0s+7ubrq7uyva+kqVtzU2mpGLG4DuYfosHcX7ArwObAGe\nGdD+DHDcUBfOnj2bjo6OUX6sJKlaixdXnvf2NiYOjcxg/8Hd09NDZ2dnzT+r6uQipbQSGPFjpVW+\n9+aIeAx4z4CXDgFezOMzJUnVu/9+WLGiss3iTZXkWnMREVOAvYADgAkRcUTxpcUppXXFPouAy1JK\ndxZf+0fgf0XEg8DPyGouzgBOyDNWSdLIPPggnHUWnHgibNiQ1V64+qbK5V3QeTXw6bLzUh3GicAv\ni78fDPy+WCKl9O8RcRFwOXA98CwwPaU0N+dYJUk7UCreXLIk+/2DH4S77oK3vKXRkakZ5b3OxQXA\nBcP0mTBI278C/5pPVJKkag0s3ty61cRCO9ZU61xIkprTiwOq3gbWW0jlTC4kSUNavDibCiln8aaG\n0myLaEmSmsiyZXDSSTBlCuy9N7z+usWbGp7JhSRpO4UCnHkmPPEETJgAv/oVHHlko6NSq3BaRJK0\nnU98Ah57DLZsgTfegC98odERqZWYXEiSKqxaBfPnV7a5dbqqYXIhSfq9NWvgtNNg27bKdgs4VQ2T\nC0kSAOvXwxlnwLPPwt13u3W6Rs+CTklqc4UCnHNONhXyxhvwf/4PnHxydkij4ciFJLW56dNh7txs\nn5Bt2+CaaxodkVqdyYUktbEtW2DBgso2izc1ViYXktSmtm2Dz34W1q2rbLd4U2NlzYUktaGU4OKL\n4bbb4Kabsp+vvurqm6oNkwtJaiOlrdOfegr6+uC66+DCC7NDqhWnRSSpjZS2Tu/ry85vv72x8Wh8\nMrmQpDaycGHlucWbyoPJhSS1ieuuy5b2LmfxpvJgzYUktYGbb4aZM7MizvnzLd5UvkwuJGkcKxTg\nD/8QnnsuSyb++3+HffZpdFQa75wWkaRx7IQTssQCstGKGTMaG4/ag8mFJI1Td92VbUJWzgJO1YPJ\nhSSNQ/ffD//5P8Nee1W2W8CpejC5kKRxolCA44+H/feHU0/NtkqfP9+t01V/FnRK0jhRWiCrZMMG\nmDIFHnqocTGpPTlyIUnjxIsvVp4XCo2JQzK5kKRx4JlnoLe3ss36CjWK0yKS1OIWL4aTToKDD4a3\nvhVef90FstRYJheS1IJKu5u+9FI2YjFlCvzsZy6QpeaQ67RIRFweEQ9HxLqIWDnCa94aETdGxMsR\nsT4iFkbERXnGKUmtplS8uWwZbNoEb3+7iYWaR941FzsDPwJurOKabwEnAV3AocC1wA0RcUbtw5Ok\n1vTyy5XnK0f0n29SfeSaXKSUvpJSuh74dRWXHQ18J6X0YEppWUrpFmABcEwuQUpSi1m1KqurKGfx\npppJM9Zc/Bj4RETcmlJaHhEnAgcD9zQ4LklquDVr4LTTYJdd4JBDoK/P4k01n2ZMLq4A3g28HBFb\ngK3A51JKcxsbliQ1TqEA55wDTzwBmzfDPffAySc3OippcFUnFxExC5g1RJcEHJNS6hllTP9ENjVy\nBrAM+CPgxoh4NaX0wI4umjlzJhMnTqxo6+rqoqura5RhSFLzOOccmFv2n1hXXWVyoep0d3fT3d1d\n0dbX15fLZ0VKqboLIvYC9h6m29KU0qaya84DZqeU9hriGiJiN2ANcGZK6e6y9n8B9k8pfXyQazqA\nefPmzaOjo6OKf4kktYbNm2HPPWH9+v62adPg+ecbF5PGh56eHjo7OwE6xzAosJ2qRy5SSiuBvOqS\no3hsHdC+FVcTldSGtmyBT34y2yeknAWcamZ5r3MxJSKOAA4AJkTEEcVj97I+iyLiLICU0jrgp8A3\nI+KEiDgwIs4HPg1YriSprWzbBp/9bFas+T//p7ubqnXkXdB5NVliUFIacjkR+GXx94OB8mKJc4Fr\ngNuAdwAvAn+bUro531AlqTmUVt/89a+zp0NuugnOPz87pFaQa3KRUroAuGCYPhMGnL8OfD7PuCSp\nmQ3cOv222+DCCxsXj1Qt6xgkqck8/XTl+auvNiYOabRMLiSpiXz967B6dWWbxZtqNc24iJYktaXr\nroMrroBLL4U5c7IRC1ffVCsyuZCkBioVbz77bLZfyMUXwze+ARGNjkwaPZMLSWqggcWb8+ebWKj1\nWXMhSQ303HOV5xZvajwwuZCkBrnrLlixorLN4k2NB06LSFID3HdfNiXy8Y9nT4f09lq8qfHD5EKS\n6qhQgFNOgaeegokTs9U3p0xpdFRSbTktIkl19NGPZst6p5SNWHR1NToiqfZMLiSpTubPz0YsylnA\nqfHI5EKS6mDhwmw65C1vqWy3gFPjkcmFJOVs8WI4+eQskXj8cbdO1/hnQack5aRQgDPOgCeegF12\ngZ/8BA49FB56qNGRSfly5EKScnLmmdlIxdatsGEDXHRRoyOS6sPkQpJy8NprWQFnOYs31S5MLiSp\nxlatyh45HcjiTbULkwtJqoFCAY4/HqZOhXe/G158MVuF0+JNtSMLOiWpBgbubnrEEXDCCRZvqj05\nciFJNbB8eeX5737XmDikZmByIUljtHlztpR3Oesr1M6cFpGkMdiyBT75yWyk4rDDYONGdzeVTC4k\naRQKBZg+HZ58EtauhVtvhfPPb3RUUnNwWkSSRmHGDJgzJ0ssAG65pbHxSM3E5EKSqpSSu5tKQzG5\nkKQqXXkl9PVVtlnAKfWz5kKSqvD1r8NXvwqzZsH992cjFhZwSpVyG7mIiAMi4paIeCEi1kfEcxFx\nVUTsPIJrr4qIV4rX/SwiDssrTkkaTmn1zb33hiuugEsvhauuyhbIev757OekSY2OUmoeeU6LHAoE\n8HngMGAmcBHwtaEuiojLgEuAPweOBnqB+yJi9xxjlaQdKq2++dvfZudz5jQ2HqnZ5ZZcpJTuTSl9\nNqX005TS0pTSXcA3genDXHoJ8LWU0p0ppYXAecBuwLl5xSpJQ3nmmcpzizelodW7oHNPYOWOXoyI\nqcC+wH2ltpTSJuAXwIdzj06SyqQE/+2/wcoB/6tl8aY0tLoVdEbEQcAXyKZHdmRfIAGFAe0F4N05\nhSZJ29m2Db7wBbjxRos3pWpVnVxExCxg1hBdEnBMSqmn7Jr9gLuBH6aUbq06Skmqk0IBzjknW3lz\n3Tq49lqYOTMr4JQ0MqMZubgB6B6mz9LSL8XE4gHg4ZTShcNc10tWBLpP8feSgefbmTlzJhMnTqxo\n6+rqoqura5iPlKR+J59cuUDWv/1bllxIra67u5vu7so/330DF2ypkUgp5fLGABGxP1li8RjwqTSC\nD4uI5cC1KaVvFs93IZsWuTSltN0CuxHRAcybN28eHR0dNY1f0vhXKGRPgyxbBuvX9z8RUjJtWva4\nqTQe9fT00NnZCdBZPuMwVrnVXBRHLH4OLAG+DEyKCABSSoWyfouAy1JKdxabrgMuj4jFwGLgcmAd\nw4+WSFLVzj4bfvWr/vNdd812Ni2xeFOqXp4FnacA04rHS8W2IKvJmFDW72Dg9/MZKaV/iIhdgf8B\nvB14BPhoSmldjrFKajPbtsH3vw+PPVbZvs8+MHmyxZvSWOSWXKSUvgN8ZwT9JgzSdjVwdR5xSWpf\npSmQJUtgzZpsR9N3vKNyKmTy5GzFTUmj594iktrGmWdWjlQcfjj89KcwfbojFVItmVxIGvc2bMge\nKX388cr29euzPUEcqZBqy+RC0rhUmgJZvBhWr4YtW7KRieXL+/tYrCnlw+RC0rh02mkwf37/eUcH\n3H23UyBSPZhcSGp5pVGKV1/NtkV/z3sqEwvIRi+cApHqw+RCUssrbYkO8MILMG8eTJ2aPRVS4hSI\nVD8mF5JaWkrbr6A5eXK2MJZTIFJjmFxIajmlaZAXX8zWqli9uvL1yZOdApEayeRCUss56yx45JH+\n84MPzpIJRymk5mByIallbNkCN9+8/ZLdW7c6SiE1E5MLSU2tNAXywgvQ19e/8NWKFf19LNaUmovJ\nhaSmdvrp2dMfJUccAT/5icWaUjMzuZDUNMrXq5g0CY4+ujKxAPjd7yzWlJqdyYWkpjFwvYpHH4Up\nU+Cll/r7OAUiNT+TC0lNo3zRK8geKX3sMadApFZjciGpYUrTIC+9lBVqvv565etTpjgFIrUikwtJ\nDXPOOTB3bv/51KnZ6ERvr6MUUiszuZBUdynBD3+Y1VSUi+ivuZDUukwuJNVFaQpk6VJYsyZ76mOv\nvWDlyv4+FmtK44PJhaS6OPPMypU13/c+eOABizWl8cjkQlKu3ngDrr8eHn+8sn3DBos1pfHK5EJS\nzZWmQBYvzpbs3rQJ9t03G6EocQpEGr9MLiTV3Mc+Bk880X9+1FFwzz1OgUjtwuRC0piVRipefjmb\nBuntrXy9r88pEKmdmFxIGrPp02HOnP7zN785SzJKnAKR2ovJhaQxuffeyqdAIKuvmDzZKRCpXZlc\nSKpKaQpk2TJYuxZWrYK3vQ02b+7vM3myUyBSOzO5kFSVs86CRx7pP3/Pe+AXv+jfKt2RCklvyuuN\nI+KAiLglIl6IiPUR8VxEXBUROw9xzU4R8Y2IeDIi1kbEKxHxnYhwxlZqsK1b4ZZbtp8C2bwZ9tkn\nG6l4/vns56RJjYlRUnPIc+TiUCCAzwPPA4cDtwC7AV/ewTW7AUcCXwGeBN4OXA/cCXwgx1glDaI0\nBbJkSfbEx7p18M53wmuv9fexWFPSQLklFymle4F7y5qWRsQ3gYvYQXKRUloDnFreFhF/ATwSEZNT\nSi/nFa+k7Z1+Osyb13/+/vfDffe5XoWkodW75mJPYOWwvba/JgGrax+OpHKlkYpXXoEtW7J1K8qt\nXet6FZJsEm3ZAAALqklEQVSGV7fkIiIOAr4AzKzimjcD1wDfTymtzSs2SZmB61Xssku2dHeJUyCS\nRqLq5CIiZgGzhuiSgGNSSj1l1+wH3A38MKV06wg/Zyfgh2R1GxdXG6ek6jzySOUUCGTJhOtVSKrW\naEYubgC6h+mztPRLMbF4AHg4pXThSD6gmFjcDhwAfGQkoxYzZ85k4sSJFW1dXV10dXWN5COltlOa\nAnnppWyH0tdeg912q+zjehXS+NHd3U13d+Wf776+vlw+K1JKubwxQETsT5ZYPAZ8Ko3gw8oSi2nA\niSmlIWs0IqIDmDdv3jw6OjpqELXUHj78YZg7t//8oIPgwQfhv/yXypEKHyuVxq+enh46OzsBOstn\nHMYqt5qL4ojFz4ElZE+HTIoIAFJKhbJ+i4DLUkp3FhOLfyN7HPUMYOeI2KfYdWVKqWwNQEmjkVKW\nNAxcryKlLKFwpELSWOVZ0HkK2ejDNOClYluQ1WRMKOt3MFCaz9ifLKkAmD/gmhOBX+YYrzRulaZA\nXnwR1qzJjre/PVu6u8RiTUm1ktsKnSml76SUJgw43pRSmjCg34SU0neLv7+4o2tSSiYWdVIowLHH\nwq67ZscHPgArVjQ6Ko3FJz4BDz+cPVq6Zg0cdhgsWgTHHQfTpmU/LdaUVCvuLaLtzJgBjz7af/7Y\nY7DffrBgAbzvfY2LSyNXGqlYvjw7X7Kk8vWNG12vQlJ+chu5UOt69dXt27ZuhcMPhze/2ZGMVjBj\nRjZSsWRJduw8YEcfp0Ak5cmRC23nXe+CF14Y/LVNm7KRjIMOyjap8kmC5vPMM9AzoOZ7v/1cr0JS\n/ZhcaDt33AFnnlk5NTLQ2rVOlTSL8iW733gjG1XaacD/Z7tehaR6clpE25k0KVut8amnYMKEHfcr\nTZU4TdJY06dnUyBLl2YjE5Mnw29+Y7GmpMYxudAOve99WUHgBz4AxSVKBvXYY7DvviYZjfDAA9uv\nVzFhArz73dlIxfPPZz+dvpJUTyYXGlJpFKO3N0sediSl/loME4z8FApw/PFZ8vCOd8BJJ2WPC5ez\nWFNSo5lcaERGOlWydm02irHHHnDggdkfwhUr+v8oHnRQ9vOpp4Y+b7Vr6pFQbdsGJ5+cTYG89BKs\nXAmHHALPPecUiKTmkuveIvXg3iL1t2JF9kd17bDbyWUOOyz7uXBhf9tb3pJtllWy226wfn3/ealI\n9Omnd9xn4Pnhh2c/n3pq5Nf8p/+UTfk8+eTIrzniiOznggWV8e60E7z+Ouy9N1xxBXz969lmYO98\nJ1x7bdbvr/6qv8+VV8Lf/V1/nyuvhKuv7j//1reyEaEvfjFbWXP9+qxgs9y0adnUhySNRl57i5hc\naFRWrMieKHnssewPoOpjYKJz3HE+BSJp9PJKLpwW0agMrMUYquDzmGOyo9weewx93tmZHeV2333o\n846O7KjmmqOOyo5qrjnyyOwot8sulecDp4722y87huozkmve+U6nQCQ1P9e50JiUkozSSEZpqmCn\nnbKh/8mT+/8ATp/ev4jTP/8zXHjhjs9b7ZrS4mIlu+0Gv/td//nUqdnP0nLcg/UZyTWuVyGpFTgt\nItXAihVDJyi1SmLuuMPHSiXVTl7TIo5cSDUw2CZgg40wDNdnJNdIUrOz5kKSJNWUyYUkSaopkwtJ\nklRTJheSJKmmTC4kSVJNmVxIkqSaMrmQJEk1ZXIhSZJqyuRCkiTVlMmFJEmqKZMLSZJUUyYXkiSp\npkwuJElSTZlcaFS6u7sbHULb8Z7Xn/e8/rzn40NuyUVEHBARt0TECxGxPiKei4irImLnKt7jpojY\nFhFfzCtOjY7/A1B/3vP6857Xn/d8fNgpx/c+FAjg88DzwOHALcBuwJeHuzgizgGOBV7JMUZJklRj\nuY1cpJTuTSl9NqX005TS0pTSXcA3genDXRsR+wPXA+cCW/KKUZIk1V69ay72BFYO1SEiAvgu8A8p\npWfqEpUkSaqZPKdFKkTEQcAXgJnDdP0bYFNK6dsjfOtdAZ55xjyknvr6+ujp6Wl0GG3Fe15/3vP6\n857XV9nfzl1r+sYppaoOYBawbYhjK9Ax4Jr9gN8A/zzMe3cCrwL7lrUtAb44xDXnAsnDw8PDw8Nj\n1Me51eYDQx1R/AM9YhGxF7D3MN2WppQ2FfvvBzwAzE0pXTDMe18C/FPxH1oygSxpWZZSmjbINe8A\nTgWWAhtH+M+QJEnZiMWBwL0ppd/W6k2rTi6qevOsMPMB4DHgU2mYD4uItwPvGtD8E7IajFtTSs/l\nEqgkSaqZ3GouiiMWPyeb1vgyMCmr1YSUUqGs3yLgspTSnSmlVcCqAe+zGeg1sZAkqTXkWdB5CjCt\neLxUbAuyKY8JZf0OBiYO8T75Da1IkqSay3VaRJIktR/3FpEkSTVlciFJkmqq5ZKL0W6IFhG3FjdB\nKz/m1CvuVjaWTeiK/V4pXveziDisHjGPBxFxeUQ8HBHrImLIlW3LrvF7PgajuefF6/yej1JE7BkR\nt0XE6uLx3YgYqg7P73mVIuLPi//7vSEiHouI44fpf0JEPF7svzgiLqz2M1suuaByQ7TDyFb8vAj4\n2giuvRvYB9i3eHw8pxjHm1Hd84i4DLgE+HPgaKAXuC8ids812vFjZ+BHwI1VXuf3fPSqvud+z8es\nG3g/8FGyNYuOJFt+YDh+z0cgIv4rMBv4O7J7+xBwd0RM3kH/A4H/AH5R7H8N8K3iZqIjV8sVuRp1\nAH8NLB6mz63AHY2OdbwcI7zny4G/LjvfhexR4883Ov5WOoDzgJUj7Ov3vP733O/56O/zoWSLJB5d\n1nZsse3gIa7zez7ye/wr4NsD2hYCX9tB/28ATw9ouxF4uJrPbcWRi8EMuyFa0R9HRCEino2ImyPi\nnXkHNo4Nec8jYirZf03cV2pL2aqtvwA+nHt07c3veZ34PR+zDwGrU0qPlxpSSo8AfQx///yeD6M4\ndd1J2fez6Cfs+P5+sPh6uXuBoyNiwiD9B9XyyUXZhmjDDWP+X+CTwInAXwHHAD8dSd2AKo3wnu9L\ntkZJYUB7ofia8uH3vL78no/NvsCKQdpXMPT983s+MnuTrStVzfdz3x3034nht/74vaZJLiJi1iAF\nOuXH1ojoGHDNfmTzbj9MKd061PunlG5PKd2dUlqYUvoP4GPAIcDpuf2jmlze91zbG809r4bf8+3l\nfc+1Pb/nqtuW6yNwA1lhz1CWln6J/g3RHk4pVV3JmlLqjYhlZCuEtqs873kvWRHoPsXfSwaet5uq\n7vlY+T0H8r3nfs8HN9J7fgQwaZDXJlHF/fN7vkOvk+1Uvs+A9qG+n7076L+l+H4j0jTJRUppJSOr\nmxi4IdpnRvN5EbE3MIVsi/e2lOc9TyktiYhesmXgFxTfYxfgBODS0cbc6qq557Xg9zzfe+73fHAj\nvecRMReYGBFHl+ouIuJY4G3AiB8t9Xs+uJTS5oiYR/b9vLPspVOAf9/BZXOBMwa0nQo8nlLaOtLP\nbpppkZGK/g3RXqR/Q7R9ImKfAf0WRcRZxd93j4h/jIgPRrZmwx+T3egVwP9f139ACxrNPS+6Drg8\nIs6OiMOBfwXWMfx/0QiIiCkRcQRwADAhIo4oHruX9fF7XkPV3vMiv+ejlFJaRFYs+C8RcWxEfBC4\nGfhxKtus0u/5mFwLfC4iLoiIQyNiNlkidiNARFwTEd8p638TcEBE/FOx/2eAC4B/rOpTG/2YzCge\nqzmPbJin/NgGbB3Qbyvw6eLvuwL3kA33bCTbqfX/A/Zv9L+nFY7R3POytiuBV4D1wM+Awxr972mV\ng+xxu4H3fSvwR4Pdc7/n9b/nZW1+z0d/zyeSrWuxunh8B3jbgD5+z8d2jy8CXgA2kI0+H1f22q3A\nAwP6/yHweLH/84zisWo3LpMkSTXVctMikiSpuZlcSJKkmjK5kCRJNWVyIUmSasrkQpIk1ZTJhSRJ\nqimTC0mSVFMmF5IkqaZMLiRJUk2ZXEiSpJoyuZAkSTX1/wDU7N6ZbPJoiAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fda3e04ec50>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot([vcom(t)[0] for t in tsample], [vcom(t)[1] for t in tsample], \"b.-\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x7fda0451ec90>]"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAhIAAAFkCAYAAAB1rtL+AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAPYQAAD2EBqD+naQAAHhpJREFUeJzt3X20XXV95/H3NwkkAcINBEwMz6YkRBTkXkDlIQGtRau1\nXeOoc62jtTPO6LR1TaYupiPjorY6Y+1MscuWqqVFXdrbp1kjWrXozDk8P0jvRRwEQY2gCAIhcpOQ\nQEjymz/2ueXmch/O2Wff+zsP79dae91k33P2/v5yH/Ynv/3bv1+klJAkSSpjUe4CJElS9zJISJKk\n0gwSkiSpNIOEJEkqzSAhSZJKM0hIkqTSDBKSJKk0g4QkSSrNICFJkkozSEiSpNKyBomI+C8R8c2I\n2BERj0bE/46I9TlrkiRJzcvdI3Eh8Ang5cDPA0uAr0fE8qxVSZKkpkQnLdoVEccAjwGbUko35a5H\nkiTNLnePxFQrgQRsz12IJEmaW6f1SHwZWJFSumiW16wCLgEeAJ5emMokSeoJy4CTgWtTSk9UccAl\nVRykChHxp8DpwPlzvPQS4AvzX5EkST3rV4G/quJAHREkIuITwBuAC1NKj8zx8gcAPv/5z7Nx48b5\nLm1BbNmyhSuuuCJ3GZXopbaA7elkvdQWsD2drJfacu+99/L2t78dGtfSKmQPEhHxJ8AvA5tTSj9q\n4i1PA2zcuJHBwcF5rW2hDAwM2JYOZXs6Vy+1BWxPJ+ultkxS2dCArEEiIq4EhoE3Ak9FxOrGp8ZT\nSo5/kCSpw+V+auM9wJHAdcDDk7a3ZKxJkiQ1KWuPREopd5CRJElt8ELeAYaHh3OXUJleagvYnk7W\nS20B29PJeqkt86Gj5pFoRkQMAqOjo6O9OPhFkqR5MzY2xtDQEMBQSmmsimPaIyFJkkozSEiSpNIM\nEpIkqTSDhCRJKs0gIUmSSjNISJKk0gwSkiSpNIOEJEkqzSAhSZJKM0hIkqTSDBKSJKk0g4QkSSrN\nICFJkkozSEiSpNIMEpIkqTSDhCRJKs0gIUmSSjNISJKk0gwSkiSpNIOEJEmZrVsHEc9tGzbkrqh5\nS3IXIElSNztwAHbuhB07YHy82Fr987ZtBx/z/vvztKUMg4QkqW8980xzF/vZPr9zJ6Q0/fEXLYIj\njyy2gYFiO/JIeOEL4bTTntt/2WUL2+4qGSQkSV3nwAHYtau9XoAdO4ogMZNly54fAAYGYM2a6fdP\n9+cjjihuVczFICFJUpP27m0/AOzYMXMvQASsWPH8i/vq1XDqqc0FgIEBOPTQhfs3Wb/+4NsZ69cv\n3LnbZZCQJDUlpfZ6ASY+Pv30zOdYunT6i/rP/dz0+6fbd8QRxS2FbnLffbkrKM8gIUl94Nlnq+kF\nOHBg5nNM1wtw7LHFEwnN9gIsXbpw/yaqhkFCkjpYSvDUU+0NBhwfhz17Zj7HIYdMf3E/5ZTmA8CK\nFd3XC6BqGCQkaZ7s21dNL8D+/TOf44gjnn9RP/poOPnk2S/8k/ctXdrcgEBpOgYJSZoiJdi9u/n/\n7c/05927Zz7HkiXTX+hPOqm1XoDFixfu30WajkFCUk/Zt694rr/dXoB9+2Y+x+GHP//iPjAAJ57Y\nXAAYGCgeLbQXQL3AICGpI6RUjOZvJwCMjxfjCWayePH0F/UTToCXvKS52wArVhS9CZIK/jhIatv+\n/dP3ArQaBmbrBTjssOkv9Mcf33wvwPLl9gJIVTNISH0speemCG6nF2DXrpnPsWjR9Bf3446DF7+4\nuQCwYkXxZIGkzmOQkLrUxEJB7QSA8fFifoGZLF8+/QV+7drmegGOPLIYT2AvgNS7DBJSBlX0Auzc\nOfPxm10oaK5egIWcIlhSdzJISC2YWCio3V6AvXtnPsdCLhQkSe0ySKhv7N3b3syAE70Asy0UNF0v\nwOrVxQI8zdwGWOiFgiSpXQYJdbyJhYLa7QWYbbngmRYKOvXU1noBnCJYUr8xSGhePfts+wFg504X\nCpKkTtURQSIi/gPwfuCFwN3AlpTSTXmr6m8TCwW1euGfuq/ZhYImX9TXrWt+uWAXCpKkvLIHiYh4\nK3AF8B7glsbHr0XExpTSQ1mL61L79rXfCzDXcsHTLRS0alVrqwUuW7Zw/yaSpPmRPUgAW4A/Tyld\nPfH3iLgEeC9wWb6yFt7EQkHtzAy4Y0e5hYLmWinQhYIkSdPJGiQi4hBgCPjvUz71deC8ha+odevW\nwdatz/39pJPgmmvKh4DZlgueWCho8kX9qKOmXy3QhYIkSQshd4/EMcBi4NEp+x8F1ix8Oa2bHCIA\nHnwQXvayg/fNtFDQxEqBzfYCuFCQJKnTdO2lacuWLQwMDBy0b3h4mOHh4UwVPef2210oSJKU18jI\nCCMjIwftGx8fr/w8kWaaXWcBNG5t7Ab+ZUrpmkn7Pw6cmVK6eJr3DAKjo6OjDA4OLlyxM5guIGT8\nJ5UkaUZjY2MMDQ0BDKWUxqo4ZtYH51JKzwKjwGumfOo1FE9wdLypKxKuX5+nDkmScuiEJ/D/CPi3\nEfGuiDgtIq4ATgA+mbmuOY2PF4MjP/WpohciJbjvvtxVSZK0cLKPkUgp/W1EHA18kOcmpHpdSunH\neSub2403FnMtvOpVuSuRJCmP7EECIKX0SbqgB2Kqeh1OOKF4BFSSpH7UCbc2ulatBhdf7BMZkqT+\nZZAo6Ykn4K67vK0hSepvBomSrr++GFx58fMeUJUkqX8YJEqq14uxESeemLsSSZLyMUiUVKt5W0OS\nJINECT/9Kdxzj7c1JEkySJRw3XXFR4OEJKnfGSRKqNVg40ZY0xXrk0qSNH8MEiXU646PkCQJDBIt\n+9GP4PvfN0hIkgQGiZbV68VMlps3565EkqT8DBItqtfhzDNh1arclUiSlJ9BogUpPbe+hiRJMki0\nZOtW+PGPHR8hSdIEg0QLajVYtAguvDB3JZIkdQaDRAtqNTj7bBgYyF2JJEmdwSDRpJScP0KSpKkM\nEk2691549FEHWkqSNJlBokn1OhxyCJx/fu5KJEnqHAaJJtVq8PKXw+GH565EkqTOYZBowoEDxYqf\njo+QJOlgBokmfPvbsH27QUKSpKkMEk2o1WDZMnjFK3JXIklSZzFINKFeLwZZLl2auxJJkjqLQWIO\n+/bB9df72KckSdMxSMxhbAx27nR8hCRJ0zFIzKFWKx75PPvs3JVIktR5DBJzqNVg06ZiMipJknQw\ng8Qs9u6Fm27ytoYkSTMxSMzi9tthzx4HWkqSNBODxCzqdVi5El72styVSJLUmQwSs6jVYPNmWLw4\ndyWSJHUmg8QM9uyBW291fIQkSbMxSMzglluKwZYGCUmSZmaQmEGtBsceC6efnrsSSZI6l0FiBvV6\n8bRGRO5KJEnqXAaJaezcCd/8po99SpI0F4PENG66Cfbvd3yEJElzMUhMo1aD446DU0/NXYkkSZ3N\nIDGNWs3xEZIkNSNbkIiIkyLiqojYGhG7I+J7EfG7EZF1eayf/QzuvNPbGpIkNWNJxnOfBgTwbuAH\nwEuAq4DDgEtzFXX99ZCSAy0lSWpGtiCRUroWuHbSrgci4n8A7yFjkKjX4ZRT4OSTc1UgSVL36LQx\nEiuB7TkLmBgfIUmS5tYxQSIi1gG/CfxZrhoeewzuvtvxEZIkNavyIBERl0fEgVm2/RExOOU9a4Gv\nAX+TUrq66pqadd11xUd7JCRJas58jJH4BDAyx2semPhDI0TUgJtTSv++2ZNs2bKFgYGBg/YNDw8z\nPDzcfKVT1GqwYQOsXVv6EJIkdYSRkRFGRg6+HI+Pj1d+nkgpVX7Qpk8ecRxFiLgD+NepiWIavRmj\no6OjDA4OzvXylmzYAK9+NVx5ZaWHlSSpI4yNjTE0NAQwlFIaq+KYOeeRWAtcBzxI8ZTGCyJidUSs\nzlHPT34C99/vbQ1JklqRcx6J1wAvamw/buwLIAGLF7qYer34eNFFC31mSZK6V7YeiZTSZ1NKi6ds\ni1JKCx4ioBgfccYZcOyxOc4uSVJ36pjHP3Nz/ghJklpnkAB++EN48EHnj5AkqVUGCYreiEWLYNOm\n3JVIktRdDBIUAy0HB2HlytyVSJLUXfo+SKRU9Eh4W0OSpNb1fZC47z545BEHWkqSVEbfB4l6HZYs\ngQsuyF2JJEndp++DRK0G554LRxyRuxJJkrpPXweJAweKFT8dHyFJUjl9HSTuvhu2bXN8hCRJZfV1\nkKjXYelSeOUrc1ciSVJ36usgUavBeefB8uW5K5EkqTv1bZDYvx+uv97bGpIktaNvg8Sdd8L4uAMt\nJUlqR98GiVoNDjsMzjkndyWSJHWvvg0S9TpceCEcemjuSiRJ6l59GST27oUbb/S2hiRJ7erLIHHH\nHfDUUw60lCSpXX0ZJOp1GBiAs87KXYkkSd2tL4NErQabNhWLdUmSpPL6Lkg8/TTccovjIyRJqkLf\nBYlbb4VnnnF8hCRJVei7IFGrwapV8NKX5q5EkqTu13dBol4veiMW9V3LJUmqXl9dTnftgttv97aG\nJElV6asgcfPNsG+fAy0lSapKXwWJWg3WrIENG3JXIklSb+irIFGvF70REbkrkSSpN/RNkHjySRgd\n9baGJElV6psgccMNcOCAAy0lSapS3wSJeh1OOglOOSV3JZIk9Y6+CRK1WtEb4fgISZKq0xdBYts2\n+Pa3HR8hSVLV+iJIXHdd8dHxEZIkVasvgkStBqeeCscfn7sSSZJ6S18EiYn5IyRJUrV6Pkg8/DB8\n97ve1pAkaT70fJCYGB9x0UU5q5AkqTf1fJCo1eD002H16tyVSJLUe3o+SDg+QpKk+dPTQeKBB2Dr\nVoOEJEnzpSOCREQcGhHfiogDEXFGVcet14uZLDdvruqIkiRpso4IEsDHgIeAVOVB63U46yw46qgq\njypJkiZkDxIR8TrgNcD7gcpWwkjpufU1JEnS/FiS8+QRsRr4NPBGYE+Vx/7+9+EnP3F8hCRJ8yl3\nj8TVwJUppTurPnCtBosXw4UXVn1kSZI0ofIeiYi4HLh8lpck4BzgAuAI4A8m3trKebZs2cLAwMBB\n+4aHhxkeHgaKIHHOObBiRStHlSSpN4yMjDAyMnLQvvHx8crPEylVOr6RiDgaOGaOlz0I/DXwhin7\nFwP7gC+klN41w/EHgdHR0VEGBwenPXhKxQRU7343fOQjLZUvSVLPGhsbY2hoCGAopTRWxTEr75FI\nKW0Hts/1uoj4LeCySbvWAtcCbwG+2U4N3/kOPP64Ay0lSZpv2QZbppQemvz3iHiK4vbG1pTSw+0c\nu16HQw+F885r5yiSJGkuuQdbTlXJfZZaDV75SjjssCqOJkmSZtIxQSKl9GBKaXFK6dvtHGf//mLF\nT29rSJI0/zomSFTlrrvgySedP0KSpIXQc0GiVoPly+Hcc3NXIklS7+u5IFGvwwUXwNKluSuRJKn3\n9VSQePZZuOEGx0dIkrRQeipIjI7Crl2Oj5AkaaH0VJCo1YopsYtJuyRJ0nzruSCxaRMsybqmqSRJ\n/aNngsQzz8DNN3tbQ5KkhdQzQeK22+Dppx1oKUnSQuqZIFGvw1FHwZln5q5EkqT+0TNBolYreiMW\n9UyLJEnqfD1x2d29u7i14W0NSZIWVk8EiZtvLiajcqClJEkLqyeCRK0Gq1fDxo25K5Ekqb/0RJCo\n14vbGhG5K5Ekqb90fZDYsQP+6Z8cHyFJUg5dHyRuvBH273d8hCRJOXR9kKjV4IQTYN263JVIktR/\neiJIOD5CkqQ8ujpIPPEE3HWXtzUkScqlq4PE9ddDSg60lCQpl64OEvV6MTbixBNzVyJJUn/q6iBR\nq3lbQ5KknLo2SGzbBvfc420NSZJy6togMTpafDRISJKUT9cGiTvuKNbWWLMmdyWSJPWvrg4Sjo+Q\nJCmvrg0SDz1kkJAkKbeuDRIAmzfnrkCSpP7WtUFi/XpYtSp3FZIk9beuDRJnn527AkmS1LVB4pxz\nclcgSZK6Nkhs2QIbNuSuQpKk/ta1QQLg/vtzVyBJUn/r6iAhSZLyMkhIkqTSujpIrF+fuwJJkvpb\n1waJ0VG4777cVUiS1N+6NkhIkqT8DBKSJKk0g4QkSSote5CIiNdHxG0RsTsiHo+Iv89dkyRJas6S\nnCePiDcBnwZ+B6hRBJuX5qxJkiQ1L1uQiIjFwMeB304pfWbSp76XpyJJktSqnLc2BoG1ABExFhEP\nR8RXI+L0jDVJkqQW5AwSLwICuBz4PeD1wM+A6yJiZca6JElSkyq/tRERl1OEg5kk4ByeCzEfTil9\nsfHedwEPAW8G/ny282zZsoWBgYGD9g0PDzM8PFyyckmSesfIyAgjIyMH7RsfH6/8PJFSqvaAEUcD\nx8zxsgeA8ygGWF6QUrpl0vtvA76RUvrgDMcfBEZHR0cZHByspmhJkvrA2NgYQ0NDAEMppbEqjll5\nj0RKaTuwfa7XRcQo8AywAbilse8Q4GTgwarrkiRJ1cv21EZKaWdEfBL4UEQ8RBEeLqW49fF3ueqS\nJEnNyzqPBPB+4Fngc8By4HbgVSml6m/iSJKkymUNEiml/RS9EJfmrEOSJJWTfYpsSZLUvQwSkiSp\nNIOEJEkqzSAhSZJKM0hIkqTSDBKSJKk0g4QkSSrNICFJkkozSEiSpNIMEpIkqTSDhCRJKs0gIUmS\nSjNISJKk0gwSkiSpNIOEJEkqzSAhSZJKM0hIkqTSDBKSJKk0g4QkSSrNICFJkkozSEiSpNIMEpIk\nqTSDhCRJKs0gIUmSSjNISJKk0gwSkiSpNIOEJEkqzSAhSZJKM0hIkqTSDBKSJKk0g4QkSSrNICFJ\nkkozSEiSpNIMEpIkqTSDhCRJKs0gIUmSSjNISJKk0gwSkiSpNIOEJEkqzSAhSZJKyxokImJDRHwp\nIrZFxHhE3BQRF+WsSZIkNS93j8TXgAA2A4PAt4B/iIgXZK1KkiQ1JVuQiIhVwMnAR1NK30kp/QD4\nHeAw4PRcdUmSpOZlCxIppSeA24B3RMRhEbEEeC/wU2A0V12SJKl5SzKf/1eAfwR2AgcoQsRrU0o7\nslYlSZKaUnmPRERcHhEHZtn2R8RgRCwGvgw8DJwPnANcA3wlIlZXXZckSapepJSqPWDE0cAxc7zs\nAeBVFEFiZUrpqUnvvx+4KqX0sRmOPwiMbtq0iYGBgYM+Nzw8zPDwcBvVS5LUG0ZGRhgZGTlo3/j4\nODfccAPAUEpprIrzVB4kmj5xxC8CXwQGUkp7Ju3/LvCZlNJHZ3jfIDA6OjrK4ODgwhQrSVIPGBsb\nY2hoCCoMEjkf/7wF2A58LiLOiIhTI+IPKZ7k+ErGuiRJUpNyPrXxJHAJcDjwf4A7gPOAN6aU/l+u\nuiRJUvOyPrWRUroL+MWcNUiSpPJyz2wpSZK6mEFCkiSVZpCQJEmlGSQkSVJpBglJklSaQUKSJJVm\nkJAkSaUZJCRJUmkGCUmSVJpBQpIklWaQkCRJpRkkJElSaQYJSZJUmkFCkiSVZpCQJEmlGSQkSVJp\nBglJklSaQUKSJJVmkJAkSaUZJCRJUmkGCUmSVJpBQpIklWaQkCRJpRkkJElSaQYJSZJUmkFCkiSV\nZpCQJEmlGSQkSVJpBglJklSaQUKSJJVmkJAkSaUZJCRJUmkGCUmSVJpBQpIklWaQkCRJpRkkJElS\naQYJSZJUmkFCkiSVZpCQJEmlGSQkSVJpBokOMDIykruEyvRSW8D2dLJeagvYnk7WS22ZD/MWJCLi\nAxFxc0Q8FRHbZ3jNCRHx5YjYFRGPR8QfR8SS+aqpU/XSN2kvtQVsTyfrpbaA7elkvdSW+TCfPRKH\nAH8L/Nl0n4yIRcBXgeXAecBbgTcB/3Mea5IkSRWat//9p5Q+BBAR75zhJZcApwE/n1J6tPHa3wau\njojLUkq75qs2SZJUjZxjJF4B3D0RIhquBZYBQ3O9eWgIFjnCQ5KkrHKOR1gDTA4RpJSejIi9jc/N\nZFnx4V5SgrGxeatvwYyPjzPWCw2ht9oCtqeT9VJbwPZ0sl5qy7333jvxx2WVHTSl1PQGXA4cmGXb\nDwxOec87ge3THOtTwD9Os/9p4K2z1PA2ILm5ubm5ubmV3t7WyvV/tq3VHolPAHMNX32gyWP9FDh3\n8o6IWAkc2vjcTK4FfrVxnqebPJckSSp6Ik6muJZWoqUgkVLaDkz7KGcJtwIfiIgXpJQea+y7hCIc\njM5SwxPAX1VUgyRJ/eaWKg82b2MkIuIE4GjgJGBxRJzZ+NT3U0pPAV8H7gE+HxGXAquAPwQ+7RMb\nkiR1h2iMO6j+wBFXA++Y5lMXp5RuaLzmeOBK4FXAHuDzwKUppWfnpShJklSpeQsSkiSp9zkTgyRJ\nKs0gIUmSSuuqINHrC4FFxGBEfD0iftao/VMRcXjuusqKiA0R8aWI2BYR4xFxU0RclLuuVkXE5og4\nEBH7Gx8nb3POwtqpIuL1EXFbROxufL/9fe6ayoqIB6Z8XfZHxH/LXVc7IuLQiPhWoz1n5K6nrIi4\nJiIejIg9EfFwRHwuIl6Yu64yIuKkiLgqIrY2fm6+FxG/GxGH5K6tjGauqc3oqiBBDy8E1vjB+gZw\nP8X8Gq8FTgc+k7Gsdn0NCGAzMAh8C/iHiHhB1qpadzPFbKsvbHxcA1wFbE0pzfiocieLiDcBnwP+\nAngpxc9LNz9WnYD/Cqzmua/Vh7NW1L6PAQ9RtK2b1YA3A+uBfwGsA/5X1orKO43id9q7gRcDW4D3\nAB/JWVQbZr2mNq2qma0WcmPm2TJfBzwLrJ60763AbuCI3HXP0aZ3A49M2XcmxYyhL8pdX4n2rGrU\nfv6kfUc09l2cu74227aEYnr3D+SupWT9i4EfA7+Wu5YK2/RD4H2566iwPa8DvkNx4ToAnJG7pgrb\n9kvAPmBx7loqas/7KaY1yF5LG22Y9pra7NZtPRJzaWshsMyWAnun7JuYufOCBa6lbamYOOw24B0R\ncVjj9tJ7KWYt7cr/xU/yyxRzpHwmcx1lDQJrASJirNHd/NWIOD1zXe36z43baHc2umy7tbt5NfBp\n4O0Uj8X3jIg4mmJm4npKaX/ueiqykuomauxKvRYkpl0IjOICPdtCYJ2gBqyJiPdHxCERcRRFd1mi\n6KbtRr8CnAPspPiF+D7gtSmlHVmrat+vA9emlB7OXUhJL6Lonr0c+D3g9cDPgOsa09R3o48D/wq4\niGIq//8I/GnOgtpwNXBlSunO3IVUJSI+GhG7gG3AKRQ9xV0vItYBv0m7twa6XPYgERGXTzOAbeqg\nqcHcdZbVbPtSSvdQdC/9J4pbMQ8DPwAeo+ja7AjNticiFgNfpmjH+RSB4hrgK43/cWVX5nsvIo6j\nmMr9qjxVz6yF9kz83H84pfTFxgXrXRSh9c3ZGjBFK1+flNIfp5RuTCndnVL6S4r71v+mEciza+Hn\n5n0UtwD/YOKtGcueUYmfnY8BLwNeAzxD8bugY5T8XbCWYhzY36SUrs5T+fPluKZmn5Cq0dV1zBwv\neyCl9M/d/hHxTuCKlNLRU471IeCNKaWzJu2b6Ha6OKV0fXWVN6dk+44Fnmr8dQfFaqgdMTip2fZQ\nzFb6ZWBlKqZEn3j//cBVKaWPzVuRTSr5tfkg8BvAcZ3WNdvC1+Y8ih6wC1JK/zznfkTcBnwjpfTB\neSuyBWW+PpPeu5ZioOLLU0p3zEd9rWiyLQ8Cfw28Ycr+xRRjCr6QUnrXPJTXsja/NsdRjNE56Psv\np1bb0/j+qgG3dsrXZEKV19RmZX8sMnXAQmDzqUz7UkqPA0TEr1PcEvjGPJRWSrPtieIJmsTze1MO\n0AE9YVD6e+/XgM92WoiAlr42oxT/K9xAY/GeKMYTnExxMesIbf5uGKT4/nukuorKa+Fr81vAZZN2\nraUY5/UW4JvzU13r2vzaTPz8L66onLa10p5GEKoBd1Dc5uwoFV9Tm5I9SLQienwhsIj4DYpf7LuA\nX6DoDry0S8cU3ELxzfy5iPh9ikD07yguVl/JWFdpEfFqivr/InMpbUkp7YyITwIfioiHKMLDpRQX\n3r/LWlwJEfEKioHWdWCc4vHpPwKuSSk9lLO2Vk2tNyKeori9sbUbx+RExLkUtzVvohiHsw74EMVj\n7rdmLK2URk/EdRRPCV0KvCCiuPs0ZZB/V2jimtqc3I+dtPiIytXA/mm2TZNeczzwJYqL8ePAFcAh\nuWtvsn2fbdS8B7gTeFvumtpsz5kU83o8BjxJMR/DL+Suq432fAG4IXcdFbVlMUVQfaTxtbkW2Ji7\nrpJtOYviorSd4pbgPcAHgWW5a6ugbSc1fsd15eOfwEuA/9v4vbabYtzXnwBrctdWsj3vnOb6cwDY\nn7u2ku2Z85razJZ9jIQkSepeHXGvWpIkdSeDhCRJKs0gIUmSSjNISJKk0gwSkiSpNIOEJEkqzSAh\nSZJKM0hIkqTSDBKSJKk0g4QkSSrNICFJkkr7//j25+J5fTG4AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fda37325d50>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot([acom(t)[0] for t in tsample], [acom(t)[1] for t in tsample], \"b.-\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
You can now do:

```python
qp.save("filename")
```

to store a QP model and load it later with:

```python
CanonicalMPCQP.load("filename")
```

